### PR TITLE
Align dump and plot CLI output interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ When you also pass `--output`, pyharp appends `_<wnmin>_<wnmax>` to the
 requested stem for each generated file.
 Use `--output-dir` to place auto-generated filenames under a different
 directory without overriding the filename pattern.
+Use `--temperature-k 300,400,500` to stack multiple temperatures into one
+NetCDF with a `temperature` dimension, so data variables are written on
+`(temperature, wavenumber)`. Even a single temperature is written with a
+degenerate `temperature` dimension of length one.
 Across `pyharp.spectra`, wavenumber ranges are interpreted as
 lower-inclusive and upper-exclusive: `--wn-range=20,22` with `1 cm^-1`
 resolution samples `20` and `21`, not `22`.
@@ -121,7 +125,7 @@ for gas mixtures such as `H2O:0.1,H2:0.9`. All plot commands accept
 multi-page PDFs. These ranges are lower-inclusive and upper-exclusive. Use
 `--output` to choose the output path. Without `--output`, plots are written
 under `--output-dir` (default `output/`) with names derived from the target,
-plot type, temperature, pressure, and wavenumber range.
+plot type, pressure, temperature, and wavenumber range.
 
 Molecular line calculations also accept `--broadening-composition BROADENER:FRACTION,...`,
 for example `air:0.8,self:0.2` or `H2:0.85,He:0.15`.

--- a/README.md
+++ b/README.md
@@ -89,10 +89,14 @@ CIA pairs, and gas mixtures:
 ```bash
 pyharp-dump xsection --species H2O --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
 pyharp-dump xsection --pair H2-H2 --temperature-k 300 --pressure-bar 1 --wn-range=20,10000
-pyharp-dump transmission --species H2O --path-length-m 1 --wn-range=20,2500
+pyharp-dump transmission --species H2O --path-length-km 1 --wn-range=20,2500
 ```
 
-Use repeated `--wn-range=min,max` values to store multiple bands in one file.
+Use repeated `--wn-range=min,max` values to write one NetCDF file per band.
+When you also pass `--output`, pyharp appends `_<wnmin>_<wnmax>` to the
+requested stem for each generated file.
+Use `--output-dir` to place auto-generated filenames under a different
+directory without overriding the filename pattern.
 Across `pyharp.spectra`, wavenumber ranges are interpreted as
 lower-inclusive and upper-exclusive: `--wn-range=20,22` with `1 cm^-1`
 resolution samples `20` and `21`, not `22`.
@@ -115,9 +119,9 @@ Use `--pair` for CIA pairs, `--species` for molecules, and `--composition`
 for gas mixtures such as `H2O:0.1,H2:0.9`. All plot commands accept
 `--wn-range=min,max`; `overview` accepts multiple `--wn-range` values for
 multi-page PDFs. These ranges are lower-inclusive and upper-exclusive. Use
-`--figure` to choose the output path. Without `--figure`,
-plots are written under `output/` with names derived from the target, plot
-type, temperature, pressure, and wavenumber range.
+`--output` to choose the output path. Without `--output`, plots are written
+under `--output-dir` (default `output/`) with names derived from the target,
+plot type, temperature, pressure, and wavenumber range.
 
 Molecular line calculations also accept `--broadening-composition BROADENER:FRACTION,...`,
 for example `air:0.8,self:0.2` or `H2:0.85,He:0.15`.

--- a/docs/source/dump_cli.rst
+++ b/docs/source/dump_cli.rst
@@ -18,8 +18,9 @@ or ``--composition`` where supported.
    pyharp-dump transmission --composition H2:0.9,He:0.1,H2O:0.002 --path-length-km 1 --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
 
 Without ``--output``, files are written under ``--output-dir`` using names
-derived from the target, product type, thermodynamic state, and wavenumber
-range.
+derived from the target, product type, pressure, temperature, and wavenumber
+range. Generated names end with ``cm1`` to indicate wavenumber bounds in
+``cm^-1``.
 
 Subcommands
 -----------
@@ -76,7 +77,11 @@ Shared Options
     Wavenumber spacing in ``cm^-1``. The default is ``1``.
 
 ``--temperature-k value``
-    Temperature in kelvin. The default is ``300``.
+    Temperature in kelvin. The default is ``300``. Use a comma-separated list
+    such as ``300,400,500`` to stack multiple temperatures into one NetCDF.
+    Data variables are always written on ``(temperature, wavenumber)``; a
+    single temperature produces a degenerate temperature dimension of length
+    one.
 
 ``--pressure-bar value``
     Pressure in bar. The default is ``1``.
@@ -143,6 +148,9 @@ This writes one file for ``[20, 2500)`` and one file for ``[2500, 10000)``.
 Adjacent repeated ranges do not duplicate the boundary sample. If
 ``--output output/h2o.nc`` is provided, the generated files are
 ``output/h2o_20_2500.nc`` and ``output/h2o_2500_10000.nc``.
+
+Auto-generated filenames follow the pattern
+``<target>_<product>_<pressure>bar_<temperature>K_<wnmin>_<wnmax>cm1``.
 
 NetCDF Naming Conventions
 -------------------------
@@ -217,7 +225,7 @@ Single-species xsection with custom broadening:
        --broadening-composition H2:0.9,He:0.1 \
        --wn-range=20,2500
 
-Multi-band xsection in one file:
+Multi-band xsection in one run:
 
 .. code-block:: bash
 

--- a/docs/source/dump_cli.rst
+++ b/docs/source/dump_cli.rst
@@ -15,10 +15,11 @@ or ``--composition`` where supported.
 
    pyharp-dump xsection --species H2O --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
    pyharp-dump xsection --pair H2-He --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
-   pyharp-dump transmission --composition H2:0.9,He:0.1,H2O:0.002 --path-length-m 1000 --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
+   pyharp-dump transmission --composition H2:0.9,He:0.1,H2O:0.002 --path-length-km 1 --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
 
-Without ``--output``, files are written under ``output/`` with names derived
-from the target, product type, thermodynamic state, and wavenumber range.
+Without ``--output``, files are written under ``--output-dir`` using names
+derived from the target, product type, thermodynamic state, and wavenumber
+range.
 
 Subcommands
 -----------
@@ -57,17 +58,19 @@ Examples:
 
 .. code-block:: bash
 
-   pyharp-dump transmission --species H2O --path-length-m 1 --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
-   pyharp-dump transmission --pair H2-He --path-length-m 1000 --temperature-k 300 --pressure-bar 1 --wn-range=20,10000
-   pyharp-dump transmission --composition H2:0.9,He:0.1,H2O:0.002 --path-length-m 1000 --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
+   pyharp-dump transmission --species H2O --path-length-km 1 --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
+   pyharp-dump transmission --pair H2-He --path-length-km 1 --temperature-k 300 --pressure-bar 1 --wn-range=20,10000
+   pyharp-dump transmission --composition H2:0.9,He:0.1,H2O:0.002 --path-length-km 1 --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
 
 Shared Options
 --------------
 
 ``--wn-range=min,max``
-    Wavenumber bounds in ``cm^-1``. Repeat this option to write multiple bands
-    into one NetCDF file. Ranges are lower-inclusive and upper-exclusive, so
-    ``--wn-range=20,22`` with ``--resolution 1`` samples ``20`` and ``21``.
+    Wavenumber bounds in ``cm^-1``. Repeat this option to write one NetCDF
+    file per band. When ``--output`` is provided with multiple ranges,
+    pyharp appends ``_<wnmin>_<wnmax>`` to the requested stem. Ranges are
+    lower-inclusive and upper-exclusive, so ``--wn-range=20,22`` with
+    ``--resolution 1`` samples ``20`` and ``21``.
 
 ``--resolution value``
     Wavenumber spacing in ``cm^-1``. The default is ``1``.
@@ -78,12 +81,16 @@ Shared Options
 ``--pressure-bar value``
     Pressure in bar. The default is ``1``.
 
-``--path-length-m value``
-    Propagation path length in meters. This option is required only for
+``--path-length-km value``
+    Transmission path length in kilometers. This option is required only for
     ``transmission`` and defaults to ``1``.
 
 ``--output path``
     Explicit NetCDF output path.
+
+``--output-dir path``
+    Directory used for auto-generated NetCDF filenames. This is ignored when
+    ``--output`` is provided.
 
 ``--hitran-dir path``
     Directory used for cached HITRAN line and CIA files. The default is
@@ -132,18 +139,10 @@ Repeat ``--wn-range`` to compute multiple bands in one run:
    pyharp-dump xsection --species H2O --temperature-k 300 --pressure-bar 1 \
        --wn-range=20,2500 --wn-range=2500,10000
 
-This produces bands on ``[20, 2500)`` and ``[2500, 10000)``, so adjacent
-repeated ranges do not duplicate the boundary sample.
-
-Multi-band outputs contain:
-
-* ``band`` and ``wavenumber`` dimensions
-* ``wavenumber``
-* ``band_size``
-* ``band_wavenumber_min``
-* ``band_wavenumber_max``
-
-Per-band data variables are stored as ``(band, wavenumber)`` arrays.
+This writes one file for ``[20, 2500)`` and one file for ``[2500, 10000)``.
+Adjacent repeated ranges do not duplicate the boundary sample. If
+``--output output/h2o.nc`` is provided, the generated files are
+``output/h2o_20_2500.nc`` and ``output/h2o_2500_10000.nc``.
 
 NetCDF Naming Conventions
 -------------------------
@@ -235,7 +234,7 @@ Composition transmission dump:
 
    pyharp-dump transmission \
        --composition H2:0.9,He:0.1,CH4:0.004,H2O:0.002 \
-       --path-length-m 1000 \
+       --path-length-km 1 \
        --temperature-k 300 \
        --pressure-bar 1 \
        --wn-range=20,2500

--- a/docs/source/plot_cli.rst
+++ b/docs/source/plot_cli.rst
@@ -22,9 +22,9 @@ Choose one subcommand, then choose the target data source with ``--pair``,
 
 Every command writes a figure. Use ``--output`` to select an explicit output
 path. Without ``--output``, plots are written under ``--output-dir`` using a
-name derived from the target, plot type, temperature, pressure, and
+name derived from the target, plot type, pressure, temperature, and
 wavenumber range, such as
-``output/co2_xsection_300K_1bar_20_2500.png``.
+``output/co2_xsection_1bar_300K_20_2500cm1.png``.
 
 Subcommands
 -----------
@@ -201,8 +201,8 @@ Default filenames are normalized for shells and filesystems:
 .. code-block:: bash
 
    pyharp-plot xsection --species CO2 --temperature-k 275.5 --pressure-bar 0.25 --wn-range=25,30.5
-   # writes output/co2_xsection_275p5K_0p25bar_25_30p5.png
+   # writes output/co2_xsection_0p25bar_275p5K_25_30p5cm1.png
 
    pyharp-plot overview --composition H2O:0.1,H2:0.9 --wn-range=25,2500
-   # writes output/h2o_0p1_h2_0p9_overview_300K_1bar_25_2500.pdf
-   # also writes output/h2o_0p1_h2_0p9_overview_300K_1bar_25_2500.manifest.json
+   # writes output/h2o_0p1_h2_0p9_overview_1bar_300K_25_2500cm1.pdf
+   # also writes output/h2o_0p1_h2_0p9_overview_1bar_300K_25_2500cm1.manifest.json

--- a/docs/source/plot_cli.rst
+++ b/docs/source/plot_cli.rst
@@ -20,10 +20,11 @@ Choose one subcommand, then choose the target data source with ``--pair``,
    pyharp-plot transmission --composition H2O:0.1,H2:0.9 --temperature-k 300 --pressure-bar 1 --path-length-km 1 --wn-range=25,2500
    pyharp-plot overview --species H2O --temperature-k 300 --pressure-bar 1 --path-length-km 1 --wn-range=20,2500
 
-Every command writes a figure. Use ``--figure`` to select an explicit output
-path. Without ``--figure``, plots are written under ``output/`` using a name
-derived from the target, plot type, temperature, pressure, and wavenumber
-range, such as ``output/co2_xsection_300K_1bar_20_2500.png``.
+Every command writes a figure. Use ``--output`` to select an explicit output
+path. Without ``--output``, plots are written under ``--output-dir`` using a
+name derived from the target, plot type, temperature, pressure, and
+wavenumber range, such as
+``output/co2_xsection_300K_1bar_20_2500.png``.
 
 Subcommands
 -----------
@@ -37,7 +38,7 @@ uses a CIA pair selected by ``--pair``.
 .. code-block:: bash
 
    pyharp-plot binary --pair H2-H2 --temperature-k 300 --wn-range=20,10000
-   pyharp-plot binary --pair H2-He --temperature-k 500 --resolution 5 --figure output/h2_he_cia.png
+   pyharp-plot binary --pair H2-He --temperature-k 500 --resolution 5 --output output/h2_he_cia.png
 
 ``xsection``
 ~~~~~~~~~~~~
@@ -122,9 +123,13 @@ Shared Options
 ``--cia-index-url url``
     HITRAN CIA index URL. The default is ``https://hitran.org/cia/``.
 
-``--figure path``
-    Explicit figure path. Use ``.png`` for single plots and ``.pdf`` for
+``--output path``
+    Explicit output path. Use ``.png`` for single plots and ``.pdf`` for
     overview plots.
+
+``--output-dir path``
+    Directory used for auto-generated figure filenames. This is ignored when
+    ``--output`` is provided.
 
 ``--broadening-composition BROADENER:FRACTION,...``
     Line-broadening gas composition for molecular line calculations. This

--- a/python/spectra/dump_cli.py
+++ b/python/spectra/dump_cli.py
@@ -24,7 +24,7 @@ from .dataset_io import (
 )
 from .hitran_cia import load_cia_dataset
 from .hitran_lines import build_line_provider, download_hitran_lines
-from .output_names import default_output_path as default_named_output_path
+from .output_names import _format_value, default_output_path as default_named_output_path
 from .shared_cli import (
     HelpFormatter,
     build_band,
@@ -158,7 +158,9 @@ def _output_path_for_wn_range(args: argparse.Namespace, *, wn_range: tuple[float
     if len(_selected_wn_ranges(args)) <= 1:
         return output_path
     wn_min, wn_max = wn_range
-    return output_path.with_name(f"{output_path.stem}_{wn_min:g}_{wn_max:g}{output_path.suffix or suffix}")
+    return output_path.with_name(
+        f"{output_path.stem}_{_format_value(wn_min)}_{_format_value(wn_max)}{output_path.suffix or suffix}"
+    )
 
 
 def _xsection_dataset(

--- a/python/spectra/dump_cli.py
+++ b/python/spectra/dump_cli.py
@@ -20,7 +20,6 @@ from .dataset_io import (
     add_wavenumber_attrs,
     build_state_attrs,
     clean_var_token,
-    combine_band_datasets,
     write_dataset_via_tmp,
 )
 from .hitran_cia import load_cia_dataset
@@ -46,6 +45,9 @@ class _ZeroLineProvider:
         return np.zeros_like(np.asarray(wavenumber_grid_cm1, dtype=np.float64))
 
 
+TRANSMISSION_PATH_LENGTH_HELP = "Transmission path length in kilometers."
+
+
 def _add_selector_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--pair", default=None, metavar="PAIR", help="CIA pair target, for example H2-H2 or H2-He.")
     parser.add_argument("--species", default=None, metavar="NAME", help="Molecular target, for example CO2, H2O, CH4, NH3, or H2S.")
@@ -54,11 +56,12 @@ def _add_selector_arguments(parser: argparse.ArgumentParser) -> None:
 
 def _add_common_arguments(parser: argparse.ArgumentParser, *, include_path_length: bool = False) -> None:
     _add_selector_arguments(parser)
-    parser.add_argument("--output", type=Path, default=None, metavar="PATH", help="Output NetCDF path. Defaults to an auto-generated path under output/.")
+    parser.add_argument("--output", type=Path, default=None, metavar="PATH", help="Output NetCDF path. Defaults to an auto-generated path under --output-dir.")
+    parser.add_argument("--output-dir", type=Path, default=Path("output"), metavar="DIR", help="Directory for auto-generated NetCDF output paths.")
     parser.add_argument("--hitran-dir", type=Path, default=default_hitran_dir(), metavar="DIR", help="Directory for downloaded HITRAN line and CIA data.")
     parser.add_argument("--temperature-k", type=float, default=300.0, metavar="K", help="Gas temperature in kelvin.")
     parser.add_argument("--pressure-bar", type=float, default=1.0, metavar="BAR", help="Gas pressure in bar.")
-    parser.add_argument("--wn-range", dest="wn_ranges", action="append", type=parse_wn_range, metavar="MIN,MAX", help="Wavenumber range in cm^-1. Repeat to store multiple bands in one NetCDF.")
+    parser.add_argument("--wn-range", dest="wn_ranges", action="append", type=parse_wn_range, metavar="MIN,MAX", help="Wavenumber range in cm^-1. Repeat to write one NetCDF per band.")
     parser.add_argument("--resolution", type=float, default=1.0, metavar="CM^-1", help="Wavenumber grid spacing in cm^-1.")
     parser.add_argument("--refresh-hitran", action="store_true", help="Re-download HITRAN line tables even if cached.")
     parser.add_argument("--broadening-composition", default=None, metavar="BROADENER:FRACTION,...", help="Line-broadening gas composition for molecular line calculations, for example air:0.8,self:0.2 or H2:0.85,He:0.15.")
@@ -68,7 +71,7 @@ def _add_common_arguments(parser: argparse.ArgumentParser, *, include_path_lengt
     parser.add_argument("--cia-index-url", default="https://hitran.org/cia/", metavar="URL", help="HITRAN CIA index URL used to resolve CIA files.")
     parser.add_argument("--refresh-cia", action="store_true", help="Re-download HITRAN CIA files even if cached.")
     if include_path_length:
-        parser.add_argument("--path-length-m", type=float, default=1.0, metavar="M", help="Propagation path length in meters.")
+        parser.add_argument("--path-length-km", type=float, default=1.0, metavar="KM", help=TRANSMISSION_PATH_LENGTH_HELP)
 
 
 def _validate_single_selector(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
@@ -94,7 +97,7 @@ def _default_cli_output_path(args: argparse.Namespace, *, suffix: str) -> Path:
         pressure_bar=args.pressure_bar,
         wn_range=args.wn_range,
         suffix=suffix,
-        output_dir=Path("output"),
+        output_dir=Path(args.output_dir),
     )
 
 
@@ -102,8 +105,12 @@ def _selected_wn_ranges(args: argparse.Namespace) -> list[tuple[float, float]]:
     return list(args.wn_ranges or [(20.0, 2500.0)])
 
 
-def _combined_wn_range(wn_ranges: list[tuple[float, float]]) -> tuple[float, float]:
-    return min(wn_min for wn_min, _ in wn_ranges), max(wn_max for _, wn_max in wn_ranges)
+def _band_attr_values(wn_range: tuple[float, float]) -> dict[str, float]:
+    wn_min, wn_max = wn_range
+    return {
+        "band_wavenumber_min_cm1": float(wn_min),
+        "band_wavenumber_max_cm1": float(wn_max),
+    }
 
 
 def _args_for_wn_range(args: argparse.Namespace, wn_range: tuple[float, float]) -> argparse.Namespace:
@@ -112,22 +119,15 @@ def _args_for_wn_range(args: argparse.Namespace, wn_range: tuple[float, float]) 
     return scoped
 
 
-def _multi_range_output_path(args: argparse.Namespace, *, suffix: str) -> Path:
-    if args.output is not None:
-        return args.output
-    scoped = _args_for_wn_range(args, _combined_wn_range(_selected_wn_ranges(args)))
-    return _default_cli_output_path(scoped, suffix=suffix)
-
-
-def _write_combined_dataset(datasets: list[xr.Dataset], *, wn_ranges: list[tuple[float, float]], output_path: Path) -> None:
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    combined = combine_band_datasets(datasets, wn_ranges=wn_ranges)
-    try:
-        write_dataset_via_tmp(combined, output_path, engine=DEFAULT_NETCDF_ENGINE)
-    finally:
-        combined.close()
-        for dataset in datasets:
-            dataset.close()
+def _output_path_for_wn_range(args: argparse.Namespace, *, wn_range: tuple[float, float], suffix: str) -> Path:
+    if args.output is None:
+        scoped = _args_for_wn_range(args, wn_range)
+        return _default_cli_output_path(scoped, suffix=suffix)
+    output_path = Path(args.output)
+    if len(_selected_wn_ranges(args)) <= 1:
+        return output_path
+    wn_min, wn_max = wn_range
+    return output_path.with_name(f"{output_path.stem}_{wn_min:g}_{wn_max:g}{output_path.suffix or suffix}")
 
 
 def _xsection_dataset(
@@ -135,6 +135,7 @@ def _xsection_dataset(
     *,
     species_name: str | None = None,
     secondary_component: dict[str, object] | None = None,
+    wn_range: tuple[float, float] | None = None,
 ) -> xr.Dataset:
     dataset = spectrum_to_dataset(spectrum)
     keep = ("sigma_line_cm2_molecule", "sigma_cia_cm2_molecule", "sigma_total_cm2_molecule")
@@ -177,6 +178,8 @@ def _xsection_dataset(
             binary,
             {"long_name": f"{secondary_component['label']} CIA binary absorption coefficient", "units": "cm^5 molecule^-2"},
         )
+    if wn_range is not None:
+        dataset.attrs.update(_band_attr_values(wn_range))
     return dataset
 
 
@@ -234,7 +237,7 @@ def _composition_xsection_dataset(args: argparse.Namespace) -> xr.Dataset:
             species_name=",".join(_composition_species_names(str(args.composition))),
             temperature_k=spectrum.temperature_k,
             pressure_pa=spectrum.pressure_pa,
-            extra={"composition_input": str(args.composition)},
+            extra={"composition_input": str(args.composition), **_band_attr_values(args.wn_range)},
         ),
     )
     add_wavenumber_attrs(dataset)
@@ -247,6 +250,7 @@ def _species_transmission_dataset(
     transmittance,
     species_name: str,
     secondary_component: dict[str, object] | None = None,
+    wn_range: tuple[float, float] | None = None,
 ) -> xr.Dataset:
     species_token = clean_var_token(species_name)
     data_vars: dict[str, tuple[tuple[str], np.ndarray, dict[str, str]]] = {
@@ -312,7 +316,7 @@ def _species_transmission_dataset(
             species_name=str(species_name),
             temperature_k=transmittance.temperature_k,
             pressure_pa=transmittance.pressure_pa,
-            extra={"path_length_m": float(transmittance.path_length_m)},
+            extra={"path_length_m": float(transmittance.path_length_m), **({} if wn_range is None else _band_attr_values(wn_range))},
         ),
     )
     add_wavenumber_attrs(dataset)
@@ -321,7 +325,7 @@ def _species_transmission_dataset(
 
 def _pair_transmission_dataset(args: argparse.Namespace) -> xr.Dataset:
     spectrum = _compute_pair_xsection(args)
-    transmittance = compute_transmittance_spectrum(spectrum=spectrum, path_length_m=args.path_length_m)
+    transmittance = compute_transmittance_spectrum(spectrum=spectrum, path_length_m=float(args.path_length_km) * 1000.0)
     pair, _ = _resolve_pair_filename(args)
     pair_token = clean_var_token(pair)
     dataset = xr.Dataset(
@@ -352,7 +356,7 @@ def _pair_transmission_dataset(args: argparse.Namespace) -> xr.Dataset:
             species_name=pair,
             temperature_k=transmittance.temperature_k,
             pressure_pa=transmittance.pressure_pa,
-            extra={"path_length_m": float(transmittance.path_length_m)},
+            extra={"path_length_m": float(transmittance.path_length_m), **_band_attr_values(args.wn_range)},
         ),
     )
     add_wavenumber_attrs(dataset)
@@ -427,7 +431,7 @@ def _composition_transmission_dataset(args: argparse.Namespace) -> xr.Dataset:
             species_name=",".join(_composition_species_names(str(args.composition))),
             temperature_k=transmittance.temperature_k,
             pressure_pa=transmittance.pressure_pa,
-            extra={"composition_input": str(args.composition), "path_length_m": path_length_m},
+            extra={"composition_input": str(args.composition), "path_length_m": path_length_m, **_band_attr_values(args.wn_range)},
         ),
     )
     add_wavenumber_attrs(dataset)
@@ -440,9 +444,10 @@ def _write_xsection_dataset(
     *,
     species_name: str | None = None,
     secondary_component: dict[str, object] | None = None,
+    wn_range: tuple[float, float] | None = None,
 ) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    dataset = _xsection_dataset(spectrum, species_name=species_name, secondary_component=secondary_component)
+    dataset = _xsection_dataset(spectrum, species_name=species_name, secondary_component=secondary_component, wn_range=wn_range)
     try:
         write_dataset_via_tmp(dataset, output_path, engine=DEFAULT_NETCDF_ENGINE)
     finally:
@@ -591,6 +596,7 @@ def _pair_xsection_dataset(args: argparse.Namespace) -> xr.Dataset:
             "pair_name": pair,
             "temperature_k": float(args.temperature_k),
             "source_filename": filename,
+            **_band_attr_values(args.wn_range),
         },
     )
 
@@ -606,7 +612,7 @@ def _compute_composition_products(args: argparse.Namespace):
         refresh_hitran=args.refresh_hitran,
         refresh_cia=args.refresh_cia,
         broadening_composition=args.broadening_composition,
-        path_length_km=getattr(args, "path_length_m", 1000.0) / 1000.0,
+        path_length_km=getattr(args, "path_length_km", 1.0),
         manifest=None,
     )
     return compute_mixture_overview_products(mixture_args, wn_range=args.wn_range)
@@ -627,6 +633,7 @@ def _compute_xsection_band(task: tuple[str, argparse.Namespace]) -> tuple[xr.Dat
             spectrum,
             species_name=str(args.species or "CO2"),
             secondary_component=secondary_component,
+            wn_range=args.wn_range,
         )
         return dataset, broadening_summary
 
@@ -640,12 +647,13 @@ def _compute_transmission_band(task: tuple[str, argparse.Namespace]) -> tuple[xr
         dataset = _composition_transmission_dataset(args)
     else:
         spectrum, broadening_summary, secondary_component = _compute_species_xsection(args)
-        transmittance = compute_transmittance_spectrum(spectrum=spectrum, path_length_m=args.path_length_m)
+        transmittance = compute_transmittance_spectrum(spectrum=spectrum, path_length_m=float(args.path_length_km) * 1000.0)
         dataset = _species_transmission_dataset(
             spectrum=spectrum,
             transmittance=transmittance,
             species_name=str(args.species or "CO2"),
             secondary_component=secondary_component,
+            wn_range=args.wn_range,
         )
     return dataset, broadening_summary
 
@@ -677,7 +685,7 @@ def build_parser() -> argparse.ArgumentParser:
             Examples:
               pyharp-dump xsection --species CO2 --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
               pyharp-dump xsection --pair H2-He --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
-              pyharp-dump transmission --composition H2:0.9,He:0.1,CH4:0.004 --path-length-m 1000 --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
+              pyharp-dump transmission --composition H2:0.9,He:0.1,CH4:0.004 --path-length-km 1 --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
 
             Run "pyharp-dump COMMAND -h" for command-specific options.
             """
@@ -710,9 +718,9 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=dedent(
             """\
             Examples:
-              pyharp-dump transmission --species CO2 --path-length-m 1 --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
-              pyharp-dump transmission --pair H2-H2 --path-length-m 1000 --temperature-k 300 --pressure-bar 1 --wn-range=20,10000
-              pyharp-dump transmission --composition H2:0.9,He:0.1,CH4:0.004 --path-length-m 1000 --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
+              pyharp-dump transmission --species CO2 --path-length-km 1 --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
+              pyharp-dump transmission --pair H2-H2 --path-length-km 1 --temperature-k 300 --pressure-bar 1 --wn-range=20,10000
+              pyharp-dump transmission --composition H2:0.9,He:0.1,CH4:0.004 --path-length-km 1 --temperature-k 300 --pressure-bar 1 --wn-range=20,2500
             """
         ),
     )
@@ -729,8 +737,8 @@ def main() -> None:
         wn_ranges = _selected_wn_ranges(args)
         target_kind, _ = _selected_target(args)
         if target_kind in {"pair", "composition"}:
-            output_path = _multi_range_output_path(args, suffix=".nc")
             if len(wn_ranges) == 1:
+                output_path = _output_path_for_wn_range(args, wn_range=wn_ranges[0], suffix=".nc")
                 dataset, _ = _compute_xsection_band((target_kind, _args_for_wn_range(args, wn_ranges[0])))
                 try:
                     write_dataset_via_tmp(dataset, output_path, engine=DEFAULT_NETCDF_ENGINE)
@@ -740,20 +748,25 @@ def main() -> None:
                 return
             tasks = [(target_kind, _args_for_wn_range(args, wn_range)) for wn_range in wn_ranges]
             results = _parallel_band_results(tasks, worker=_compute_xsection_band)
-            datasets = [dataset for dataset, _ in results]
-            _write_combined_dataset(datasets, wn_ranges=wn_ranges, output_path=output_path)
-            print(f"Wrote NetCDF: {output_path}")
+            for wn_range, (dataset, _) in zip(wn_ranges, results, strict=True):
+                output_path = _output_path_for_wn_range(args, wn_range=wn_range, suffix=".nc")
+                try:
+                    write_dataset_via_tmp(dataset, output_path, engine=DEFAULT_NETCDF_ENGINE)
+                finally:
+                    dataset.close()
+                print(f"Wrote NetCDF: {output_path}")
             return
         if len(wn_ranges) == 1:
             range_args = _args_for_wn_range(args, wn_ranges[0])
             broadening_summary: str | None = None
             spectrum, broadening_summary, secondary_component = _compute_species_xsection(range_args)
-            output_path = _multi_range_output_path(args, suffix=".nc")
+            output_path = _output_path_for_wn_range(args, wn_range=wn_ranges[0], suffix=".nc")
             _write_xsection_dataset(
                 spectrum,
                 output_path,
                 species_name=str(range_args.species or "CO2"),
                 secondary_component=secondary_component,
+                wn_range=range_args.wn_range,
             )
             print(f"Wrote NetCDF: {output_path}")
             if broadening_summary:
@@ -761,14 +774,15 @@ def main() -> None:
             return
         tasks = [("species", _args_for_wn_range(args, wn_range)) for wn_range in wn_ranges]
         results = _parallel_band_results(tasks, worker=_compute_xsection_band)
-        datasets = [dataset for dataset, _ in results]
-        for _, broadening_summary in results:
+        for wn_range, (dataset, broadening_summary) in zip(wn_ranges, results, strict=True):
+            output_path = _output_path_for_wn_range(args, wn_range=wn_range, suffix=".nc")
+            try:
+                write_dataset_via_tmp(dataset, output_path, engine=DEFAULT_NETCDF_ENGINE)
+            finally:
+                dataset.close()
+            print(f"Wrote NetCDF: {output_path}")
             if broadening_summary:
                 print(f"Broadening: {broadening_summary}")
-        if len(wn_ranges) > 1:
-            output_path = _multi_range_output_path(args, suffix=".nc")
-            _write_combined_dataset(datasets, wn_ranges=wn_ranges, output_path=output_path)
-            print(f"Wrote NetCDF: {output_path}")
         return
     if args.command == "transmission":
         wn_ranges = _selected_wn_ranges(args)
@@ -776,7 +790,7 @@ def main() -> None:
         if len(wn_ranges) == 1:
             range_args = _args_for_wn_range(args, wn_ranges[0])
             dataset, broadening_summary = _compute_transmission_band((target_kind, range_args))
-            output_path = _multi_range_output_path(args, suffix=".nc")
+            output_path = _output_path_for_wn_range(args, wn_range=wn_ranges[0], suffix=".nc")
             try:
                 write_dataset_via_tmp(dataset, output_path, engine=DEFAULT_NETCDF_ENGINE)
             finally:
@@ -787,12 +801,13 @@ def main() -> None:
             return
         tasks = [(target_kind, _args_for_wn_range(args, wn_range)) for wn_range in wn_ranges]
         results = _parallel_band_results(tasks, worker=_compute_transmission_band)
-        datasets = [dataset for dataset, _ in results]
-        for _, broadening_summary in results:
+        for wn_range, (dataset, broadening_summary) in zip(wn_ranges, results, strict=True):
+            output_path = _output_path_for_wn_range(args, wn_range=wn_range, suffix=".nc")
+            try:
+                write_dataset_via_tmp(dataset, output_path, engine=DEFAULT_NETCDF_ENGINE)
+            finally:
+                dataset.close()
+            print(f"Wrote NetCDF: {output_path}")
             if broadening_summary:
                 print(f"Broadening: {broadening_summary}")
-        if len(wn_ranges) > 1:
-            output_path = _multi_range_output_path(args, suffix=".nc")
-            _write_combined_dataset(datasets, wn_ranges=wn_ranges, output_path=output_path)
-            print(f"Wrote NetCDF: {output_path}")
         return

--- a/python/spectra/dump_cli.py
+++ b/python/spectra/dump_cli.py
@@ -46,6 +46,17 @@ class _ZeroLineProvider:
 
 
 TRANSMISSION_PATH_LENGTH_HELP = "Transmission path length in kilometers."
+TEMPERATURE_COORD_ATTRS = {"long_name": "temperature", "units": "K"}
+
+
+def _parse_temperature_list(value: str) -> list[float]:
+    parts = [part.strip() for part in str(value).split(",")]
+    if not parts or any(part == "" for part in parts):
+        raise argparse.ArgumentTypeError("temperature-k must be a number or comma-separated list of numbers")
+    try:
+        return [float(part) for part in parts]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("temperature-k must contain numeric values") from exc
 
 
 def _add_selector_arguments(parser: argparse.ArgumentParser) -> None:
@@ -59,7 +70,7 @@ def _add_common_arguments(parser: argparse.ArgumentParser, *, include_path_lengt
     parser.add_argument("--output", type=Path, default=None, metavar="PATH", help="Output NetCDF path. Defaults to an auto-generated path under --output-dir.")
     parser.add_argument("--output-dir", type=Path, default=Path("output"), metavar="DIR", help="Directory for auto-generated NetCDF output paths.")
     parser.add_argument("--hitran-dir", type=Path, default=default_hitran_dir(), metavar="DIR", help="Directory for downloaded HITRAN line and CIA data.")
-    parser.add_argument("--temperature-k", type=float, default=300.0, metavar="K", help="Gas temperature in kelvin.")
+    parser.add_argument("--temperature-k", type=_parse_temperature_list, default=[300.0], metavar="K[,K...]", help="Gas temperature in kelvin. Use a comma-separated list to stack multiple temperatures into one NetCDF.")
     parser.add_argument("--pressure-bar", type=float, default=1.0, metavar="BAR", help="Gas pressure in bar.")
     parser.add_argument("--wn-range", dest="wn_ranges", action="append", type=parse_wn_range, metavar="MIN,MAX", help="Wavenumber range in cm^-1. Repeat to write one NetCDF per band.")
     parser.add_argument("--resolution", type=float, default=1.0, metavar="CM^-1", help="Wavenumber grid spacing in cm^-1.")
@@ -88,12 +99,26 @@ def _selected_target(args: argparse.Namespace) -> tuple[str, object]:
     return "species", args.species or "CO2"
 
 
+def _selected_temperatures(args: argparse.Namespace) -> list[float]:
+    values = getattr(args, "temperature_k", [300.0])
+    if isinstance(values, (list, tuple)):
+        return [float(value) for value in values]
+    return [float(values)]
+
+
+def _temperature_output_value(args: argparse.Namespace) -> float | str:
+    temperatures = _selected_temperatures(args)
+    if len(temperatures) == 1:
+        return temperatures[0]
+    return "_".join(f"{value:g}".replace("-", "m").replace(".", "p") for value in temperatures)
+
+
 def _default_cli_output_path(args: argparse.Namespace, *, suffix: str) -> Path:
     _, target = _selected_target(args)
     return default_named_output_path(
         target_name=target,
         plot_type=args.command,
-        temperature_k=args.temperature_k,
+        temperature_k=_temperature_output_value(args),
         pressure_bar=args.pressure_bar,
         wn_range=args.wn_range,
         suffix=suffix,
@@ -116,6 +141,12 @@ def _band_attr_values(wn_range: tuple[float, float]) -> dict[str, float]:
 def _args_for_wn_range(args: argparse.Namespace, wn_range: tuple[float, float]) -> argparse.Namespace:
     scoped = argparse.Namespace(**vars(args))
     scoped.wn_range = wn_range
+    return scoped
+
+
+def _args_for_temperature(args: argparse.Namespace, temperature_k: float) -> argparse.Namespace:
+    scoped = argparse.Namespace(**vars(args))
+    scoped.temperature_k = float(temperature_k)
     return scoped
 
 
@@ -503,7 +534,7 @@ def _compute_species_xsection(args: argparse.Namespace):
     line_provider = build_line_provider(config, line_db)
     cia_dataset = _resolve_species_cia(args, config)
     cia_selection = _resolve_species_cia_selection(args, config)
-    temperature_k = float(args.temperature_k)
+    temperature_k = _selected_temperatures(args)[0]
     pressure_pa = float(args.pressure_bar) * 1.0e5
     grid = band.grid()
     cia_cross_section_cm2_molecule = None
@@ -555,7 +586,7 @@ def _compute_pair_xsection(args: argparse.Namespace):
     spectrum = compute_absorption_spectrum_from_sources(
         species_name=pair,
         wavenumber_grid_cm1=band.grid(),
-        temperature_k=float(args.temperature_k),
+        temperature_k=_selected_temperatures(args)[0],
         pressure_pa=float(args.pressure_bar) * 1.0e5,
         line_provider=_ZeroLineProvider(),
         cia_dataset=cia_dataset,
@@ -576,7 +607,7 @@ def _pair_xsection_dataset(args: argparse.Namespace) -> xr.Dataset:
     grid = band.grid()
     binary = np.asarray(
         cia_dataset.interpolate_to_grid(
-            temperature_k=float(args.temperature_k),
+            temperature_k=_selected_temperatures(args)[0],
             wavenumber_grid_cm1=grid,
         ),
         dtype=np.float64,
@@ -594,7 +625,7 @@ def _pair_xsection_dataset(args: argparse.Namespace) -> xr.Dataset:
         },
         attrs={
             "pair_name": pair,
-            "temperature_k": float(args.temperature_k),
+            "temperature_k": _selected_temperatures(args)[0],
             "source_filename": filename,
             **_band_attr_values(args.wn_range),
         },
@@ -675,6 +706,74 @@ def _parallel_band_results(
         return list(executor.map(worker, tasks))
 
 
+def _stack_temperature_datasets(datasets: list[xr.Dataset], *, temperatures: list[float]) -> xr.Dataset:
+    if not datasets:
+        raise ValueError("at least one dataset is required")
+    stacked = xr.concat(
+        datasets,
+        dim=xr.IndexVariable("temperature", np.asarray(temperatures, dtype=np.float64)),
+    )
+    stacked["temperature"].attrs = dict(TEMPERATURE_COORD_ATTRS)
+    attrs = dict(datasets[0].attrs)
+    attrs.pop("temperature_k", None)
+    attrs.pop("number_density_cm3", None)
+    stacked.attrs = attrs
+    return stacked
+
+
+def _compute_temperature_stacked_dataset(
+    *,
+    base_args: argparse.Namespace,
+    target_kind: str,
+    worker,
+) -> tuple[xr.Dataset, list[str]]:
+    temperatures = _selected_temperatures(base_args)
+    tasks = [
+        (target_kind, _args_for_temperature(base_args, temperature_k))
+        for temperature_k in temperatures
+    ]
+    results = _parallel_band_results(tasks, worker=worker)
+    datasets = [dataset for dataset, _ in results]
+    broadening_summaries = [summary for _, summary in results if summary]
+    try:
+        stacked = _stack_temperature_datasets(datasets, temperatures=temperatures)
+    finally:
+        for dataset in datasets:
+            dataset.close()
+    return stacked, broadening_summaries
+
+
+def _compute_range_temperature_datasets(
+    *,
+    args: argparse.Namespace,
+    wn_ranges: list[tuple[float, float]],
+    target_kind: str,
+    worker,
+) -> list[tuple[tuple[float, float], xr.Dataset, list[str]]]:
+    temperatures = _selected_temperatures(args)
+    tasks: list[tuple[str, argparse.Namespace]] = []
+    for wn_range in wn_ranges:
+        range_args = _args_for_wn_range(args, wn_range)
+        for temperature_k in temperatures:
+            tasks.append((target_kind, _args_for_temperature(range_args, temperature_k)))
+
+    results = _parallel_band_results(tasks, worker=worker)
+    grouped: list[tuple[tuple[float, float], xr.Dataset, list[str]]] = []
+    index = 0
+    for wn_range in wn_ranges:
+        range_results = results[index:index + len(temperatures)]
+        index += len(temperatures)
+        datasets = [dataset for dataset, _ in range_results]
+        broadening_summaries = [summary for _, summary in range_results if summary]
+        try:
+            stacked = _stack_temperature_datasets(datasets, temperatures=temperatures)
+        finally:
+            for dataset in datasets:
+                dataset.close()
+        grouped.append((wn_range, stacked, broadening_summaries))
+    return grouped
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Create the dump CLI parser."""
     parser = argparse.ArgumentParser(
@@ -736,78 +835,36 @@ def main() -> None:
     if args.command == "xsection":
         wn_ranges = _selected_wn_ranges(args)
         target_kind, _ = _selected_target(args)
-        if target_kind in {"pair", "composition"}:
-            if len(wn_ranges) == 1:
-                output_path = _output_path_for_wn_range(args, wn_range=wn_ranges[0], suffix=".nc")
-                dataset, _ = _compute_xsection_band((target_kind, _args_for_wn_range(args, wn_ranges[0])))
-                try:
-                    write_dataset_via_tmp(dataset, output_path, engine=DEFAULT_NETCDF_ENGINE)
-                finally:
-                    dataset.close()
-                print(f"Wrote NetCDF: {output_path}")
-                return
-            tasks = [(target_kind, _args_for_wn_range(args, wn_range)) for wn_range in wn_ranges]
-            results = _parallel_band_results(tasks, worker=_compute_xsection_band)
-            for wn_range, (dataset, _) in zip(wn_ranges, results, strict=True):
-                output_path = _output_path_for_wn_range(args, wn_range=wn_range, suffix=".nc")
-                try:
-                    write_dataset_via_tmp(dataset, output_path, engine=DEFAULT_NETCDF_ENGINE)
-                finally:
-                    dataset.close()
-                print(f"Wrote NetCDF: {output_path}")
-            return
-        if len(wn_ranges) == 1:
-            range_args = _args_for_wn_range(args, wn_ranges[0])
-            broadening_summary: str | None = None
-            spectrum, broadening_summary, secondary_component = _compute_species_xsection(range_args)
-            output_path = _output_path_for_wn_range(args, wn_range=wn_ranges[0], suffix=".nc")
-            _write_xsection_dataset(
-                spectrum,
-                output_path,
-                species_name=str(range_args.species or "CO2"),
-                secondary_component=secondary_component,
-                wn_range=range_args.wn_range,
-            )
-            print(f"Wrote NetCDF: {output_path}")
-            if broadening_summary:
-                print(f"Broadening: {broadening_summary}")
-            return
-        tasks = [("species", _args_for_wn_range(args, wn_range)) for wn_range in wn_ranges]
-        results = _parallel_band_results(tasks, worker=_compute_xsection_band)
-        for wn_range, (dataset, broadening_summary) in zip(wn_ranges, results, strict=True):
+        for wn_range, dataset, broadening_summaries in _compute_range_temperature_datasets(
+            args=args,
+            wn_ranges=wn_ranges,
+            target_kind=target_kind,
+            worker=_compute_xsection_band,
+        ):
             output_path = _output_path_for_wn_range(args, wn_range=wn_range, suffix=".nc")
             try:
                 write_dataset_via_tmp(dataset, output_path, engine=DEFAULT_NETCDF_ENGINE)
             finally:
                 dataset.close()
             print(f"Wrote NetCDF: {output_path}")
-            if broadening_summary:
+            for broadening_summary in broadening_summaries:
                 print(f"Broadening: {broadening_summary}")
         return
     if args.command == "transmission":
         wn_ranges = _selected_wn_ranges(args)
         target_kind, _ = _selected_target(args)
-        if len(wn_ranges) == 1:
-            range_args = _args_for_wn_range(args, wn_ranges[0])
-            dataset, broadening_summary = _compute_transmission_band((target_kind, range_args))
-            output_path = _output_path_for_wn_range(args, wn_range=wn_ranges[0], suffix=".nc")
-            try:
-                write_dataset_via_tmp(dataset, output_path, engine=DEFAULT_NETCDF_ENGINE)
-            finally:
-                dataset.close()
-            print(f"Wrote NetCDF: {output_path}")
-            if broadening_summary:
-                print(f"Broadening: {broadening_summary}")
-            return
-        tasks = [(target_kind, _args_for_wn_range(args, wn_range)) for wn_range in wn_ranges]
-        results = _parallel_band_results(tasks, worker=_compute_transmission_band)
-        for wn_range, (dataset, broadening_summary) in zip(wn_ranges, results, strict=True):
+        for wn_range, dataset, broadening_summaries in _compute_range_temperature_datasets(
+            args=args,
+            wn_ranges=wn_ranges,
+            target_kind=target_kind,
+            worker=_compute_transmission_band,
+        ):
             output_path = _output_path_for_wn_range(args, wn_range=wn_range, suffix=".nc")
             try:
                 write_dataset_via_tmp(dataset, output_path, engine=DEFAULT_NETCDF_ENGINE)
             finally:
                 dataset.close()
             print(f"Wrote NetCDF: {output_path}")
-            if broadening_summary:
+            for broadening_summary in broadening_summaries:
                 print(f"Broadening: {broadening_summary}")
         return

--- a/python/spectra/output_names.py
+++ b/python/spectra/output_names.py
@@ -34,7 +34,7 @@ def default_output_path(
     *,
     target_name: object,
     plot_type: str,
-    temperature_k: float,
+    temperature_k: float | str,
     pressure_bar: float,
     wn_range: tuple[float, float],
     suffix: str,
@@ -46,10 +46,10 @@ def default_output_path(
         [
             _clean_token(target_name),
             _clean_token(plot_type),
-            _format_value(temperature_k, "K"),
             _format_value(pressure_bar, "bar"),
+            _format_value(temperature_k, "K"),
             _format_value(wn_min),
-            _format_value(wn_max),
+            _format_value(wn_max, "cm1"),
         ]
     )
     return output_dir / f"{stem}{suffix}"

--- a/python/spectra/plot_cli.py
+++ b/python/spectra/plot_cli.py
@@ -39,6 +39,7 @@ def _add_state_arguments(parser: argparse.ArgumentParser) -> None:
 
 def _add_common_arguments(parser: argparse.ArgumentParser, *, allow_multiple_ranges: bool = False) -> None:
     parser.add_argument("--hitran-dir", type=Path, default=Path("hitran"), metavar="DIR", help="Directory for downloaded HITRAN line and CIA data.")
+    parser.add_argument("--output-dir", type=Path, default=Path("output"), metavar="DIR", help="Directory for auto-generated figure output paths.")
     parser.add_argument("--resolution", type=float, default=1.0, metavar="CM^-1", help="Wavenumber grid spacing in cm^-1.")
     parser.add_argument(
         "--broadening-composition",
@@ -95,6 +96,7 @@ def _default_figure(
     temperature_k: float,
     pressure_bar: float,
     wn_range: tuple[float, float],
+    output_dir: Path = Path("output"),
     suffix: str = ".png",
 ) -> Path:
     return default_output_path(
@@ -104,6 +106,7 @@ def _default_figure(
         pressure_bar=pressure_bar,
         wn_range=wn_range,
         suffix=suffix,
+        output_dir=output_dir,
     )
 
 
@@ -131,6 +134,7 @@ def _as_cia_args(args: argparse.Namespace, *, default_pair: str, plot_type: str)
             temperature_k=args.temperature_k,
             pressure_bar=pressure_bar,
             wn_range=wn_range,
+            output_dir=args.output_dir,
         ),
     )
 
@@ -159,6 +163,7 @@ def _as_molecule_args(args: argparse.Namespace, *, plot_type: str) -> argparse.N
             temperature_k=args.temperature_k,
             pressure_bar=args.pressure_bar,
             wn_range=wn_range,
+            output_dir=args.output_dir,
         ),
     )
 
@@ -185,6 +190,7 @@ def _as_molecule_overview_args(args: argparse.Namespace, *, species: str, wn_ran
             temperature_k=args.temperature_k,
             pressure_bar=args.pressure_bar,
             wn_range=wn_range,
+            output_dir=args.output_dir,
             suffix=".pdf",
         ),
     )
@@ -210,6 +216,7 @@ def _as_molecule_overview_batch_args(args: argparse.Namespace, *, species: list[
             temperature_k=args.temperature_k,
             pressure_bar=args.pressure_bar,
             wn_range=_combined_range(wn_ranges),
+            output_dir=args.output_dir,
             suffix=".pdf",
         ),
     )
@@ -235,6 +242,7 @@ def _as_atm_overview_args(args: argparse.Namespace, *, wn_ranges: list[tuple[flo
             temperature_k=args.temperature_k,
             pressure_bar=args.pressure_bar,
             wn_range=_combined_range(wn_ranges),
+            output_dir=args.output_dir,
             suffix=".pdf",
         ),
         manifest=args.manifest,
@@ -260,6 +268,7 @@ def _as_atm_args(args: argparse.Namespace, *, plot_type: str, wn_range: tuple[fl
             temperature_k=args.temperature_k,
             pressure_bar=args.pressure_bar,
             wn_range=wn_range,
+            output_dir=args.output_dir,
         ),
     )
 
@@ -295,7 +304,7 @@ def build_parser() -> argparse.ArgumentParser:
             """\
             Examples:
               pyharp-plot binary --pair H2-H2 --temperature-k 300 --wn-range=20,10000
-              pyharp-plot binary --pair H2-He --temperature-k 500 --resolution 5 --figure output/h2_he_cia.png
+              pyharp-plot binary --pair H2-He --temperature-k 500 --resolution 5 --output output/h2_he_cia.png
             """
         ),
     )
@@ -304,7 +313,7 @@ def build_parser() -> argparse.ArgumentParser:
     binary.add_argument("--filename", default=None, metavar="FILE", help="Use a specific CIA filename instead of resolving one from --pair.")
     binary.add_argument("--temperature-k", type=float, default=300.0, metavar="K", help="Gas temperature in kelvin.")
     binary.add_argument("--refresh", action="store_true", help="Re-download the CIA file even if cached.")
-    binary.add_argument("--figure", type=Path, default=None, metavar="PATH", help="Output PNG path. Defaults to an auto-generated path under output/.")
+    binary.add_argument("--output", dest="figure", type=Path, default=None, metavar="PATH", help="Output PNG path. Defaults to an auto-generated path under --output-dir.")
 
     xsection = subparsers.add_parser(
         "xsection",
@@ -325,7 +334,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_cache_arguments(xsection)
     xsection.add_argument("--cia-filename", default=None, metavar="FILE", help="Optional CIA filename to include as the secondary continuum source.")
     xsection.add_argument("--cia-pair", default=None, metavar="PAIR", help="Optional CIA pair to resolve as the secondary continuum source.")
-    xsection.add_argument("--figure", type=Path, default=None, metavar="PATH", help="Output PNG path. Defaults to an auto-generated path under output/.")
+    xsection.add_argument("--output", dest="figure", type=Path, default=None, metavar="PATH", help="Output PNG path. Defaults to an auto-generated path under --output-dir.")
 
     for name in ("attenuation", "transmission"):
         path_help = "Transmission path length in kilometers." if name == "transmission" else None
@@ -354,7 +363,7 @@ def build_parser() -> argparse.ArgumentParser:
         subparser.add_argument("--cia-pair", default=None, metavar="PAIR", help="Optional CIA pair to include for molecular targets.")
         if name == "transmission":
             subparser.add_argument("--path-length-km", type=float, default=1.0, metavar="KM", help=path_help)
-        subparser.add_argument("--figure", type=Path, default=None, metavar="PATH", help="Output PNG path. Defaults to an auto-generated path under output/.")
+        subparser.add_argument("--output", dest="figure", type=Path, default=None, metavar="PATH", help="Output PNG path. Defaults to an auto-generated path under --output-dir.")
 
     overview = subparsers.add_parser(
         "overview",
@@ -385,7 +394,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_cache_arguments(overview)
     overview.add_argument("--cia-filename", default=None, metavar="FILE", help="Optional CIA filename to include for molecular overview pages.")
     overview.add_argument("--cia-pair", default=None, metavar="PAIR", help="Optional CIA pair to include for molecular overview pages.")
-    overview.add_argument("--figure", type=Path, default=None, metavar="PATH", help="Output PDF path. Defaults to an auto-generated path under output/.")
+    overview.add_argument("--output", dest="figure", type=Path, default=None, metavar="PATH", help="Output PDF path. Defaults to an auto-generated path under --output-dir.")
     overview.add_argument("--manifest", type=Path, default=None, metavar="PATH", help="Output manifest JSON path for composition overview PDFs.")
 
     return parser

--- a/tests/spectra/test_cli.py
+++ b/tests/spectra/test_cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import xarray as xr
 
 from pyharp.spectra.dataset_io import combine_band_datasets, write_dataset_via_tmp
-from pyharp.spectra.dump_cli import _args_for_wn_range, _composition_transmission_dataset, _composition_xsection_dataset, _pair_xsection_dataset, _species_transmission_dataset, _xsection_dataset, build_parser, main
+from pyharp.spectra.dump_cli import _args_for_wn_range, _composition_transmission_dataset, _composition_xsection_dataset, _output_path_for_wn_range, _pair_xsection_dataset, _species_transmission_dataset, _xsection_dataset, build_parser, main
 from pyharp.spectra.shared_cli import default_hitran_dir, default_output_path, project_root
 from pyharp.spectra.spectrum import AbsorptionSpectrum
 
@@ -34,6 +34,8 @@ def test_xsection_parser_accepts_species_pressure_temperature_and_outputs(tmp_pa
             "xsection",
             "--output",
             str(tmp_path / "xsection.nc"),
+            "--output-dir",
+            str(tmp_path / "named"),
             "--temperature-k",
             "300",
             "--pressure-bar",
@@ -48,6 +50,7 @@ def test_xsection_parser_accepts_species_pressure_temperature_and_outputs(tmp_pa
     )
     assert args.command == "xsection"
     assert args.output == tmp_path / "xsection.nc"
+    assert args.output_dir == tmp_path / "named"
     assert args.temperature_k == 300.0
     assert args.pressure_bar == 1.0
     assert args.species == "co2"
@@ -94,7 +97,7 @@ def test_transmission_parser_accepts_path_length_and_outputs(tmp_path) -> None:
             "300",
             "--pressure-bar",
             "1",
-            "--path-length-m",
+            "--path-length-km",
             "1.5",
             "--species",
             "CO2",
@@ -108,10 +111,25 @@ def test_transmission_parser_accepts_path_length_and_outputs(tmp_path) -> None:
     assert args.output == tmp_path / "trans.nc"
     assert args.temperature_k == 300.0
     assert args.pressure_bar == 1.0
-    assert args.path_length_m == 1.5
+    assert args.path_length_km == 1.5
     assert args.species == "CO2"
     assert args.broadening_composition == "H2:0.85,He:0.15"
     assert args.wn_ranges == [(50.0, 150.0)]
+
+
+def test_transmission_parser_defaults_path_length_to_one_km() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "transmission",
+            "--species",
+            "CO2",
+            "--wn-range",
+            "50,150",
+        ]
+    )
+
+    assert args.path_length_km == 1.0
 
 
 def test_xsection_parser_accepts_repeated_wn_ranges(tmp_path) -> None:
@@ -129,6 +147,40 @@ def test_xsection_parser_accepts_repeated_wn_ranges(tmp_path) -> None:
     )
 
     assert args.wn_ranges == [(20.0, 2500.0), (2500.0, 10000.0)]
+
+
+def test_output_path_for_multiple_ranges_appends_band_suffix(tmp_path) -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "xsection",
+            "--species",
+            "H2O",
+            "--wn-range=20,2500",
+            "--wn-range=2500,10000",
+            "--output",
+            str(tmp_path / "xsection.nc"),
+        ]
+    )
+
+    assert _output_path_for_wn_range(args, wn_range=(20.0, 2500.0), suffix=".nc") == tmp_path / "xsection_20_2500.nc"
+    assert _output_path_for_wn_range(args, wn_range=(2500.0, 10000.0), suffix=".nc") == tmp_path / "xsection_2500_10000.nc"
+
+
+def test_output_path_for_wn_range_uses_output_dir_for_generated_names(tmp_path) -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "xsection",
+            "--species",
+            "H2O",
+            "--wn-range=20,2500",
+            "--output-dir",
+            str(tmp_path / "products"),
+        ]
+    )
+
+    assert _output_path_for_wn_range(args, wn_range=(20.0, 2500.0), suffix=".nc") == tmp_path / "products" / "h2o_xsection_300K_1bar_20_2500.nc"
 
 
 def test_cli_xsection_reports_broadening_summary(monkeypatch, tmp_path, capsys) -> None:
@@ -172,7 +224,7 @@ def test_cli_xsection_reports_broadening_summary(monkeypatch, tmp_path, capsys) 
     assert "Broadening: requested=h2:0.900,he:0.100 -> effective=air:1.000" in out
 
 
-def test_cli_xsection_writes_multiple_ranges_to_one_file(monkeypatch, tmp_path, capsys) -> None:
+def test_cli_xsection_writes_one_file_per_range(monkeypatch, tmp_path, capsys) -> None:
     monkeypatch.setattr(
         sys,
         "argv",
@@ -188,6 +240,7 @@ def test_cli_xsection_writes_multiple_ranges_to_one_file(monkeypatch, tmp_path, 
         ],
     )
     calls = []
+    written = []
     monkeypatch.setattr(
         "pyharp.spectra.dump_cli._parallel_band_results",
         lambda tasks, *, worker: [
@@ -202,18 +255,21 @@ def test_cli_xsection_writes_multiple_ranges_to_one_file(monkeypatch, tmp_path, 
             for _, task_args in tasks
         ],
     )
-    written = []
     monkeypatch.setattr(
-        "pyharp.spectra.dump_cli._write_combined_dataset",
-        lambda datasets, *, wn_ranges, output_path: written.append((len(datasets), wn_ranges, output_path)),
+        "pyharp.spectra.dump_cli.write_dataset_via_tmp",
+        lambda dataset, output_path, *, engine: written.append((tuple(dataset["wavenumber"].values), output_path, engine)),
     )
 
     main()
 
     assert calls == [(20.0, 2500.0), (2500.0, 10000.0)]
-    assert written == [(2, [(20.0, 2500.0), (2500.0, 10000.0)], tmp_path / "xsection.nc")]
+    assert written == [
+        ((1.0, 2.0), tmp_path / "xsection_20_2500.nc", "scipy"),
+        ((1.0, 2.0), tmp_path / "xsection_2500_10000.nc", "scipy"),
+    ]
     out = capsys.readouterr().out
-    assert "Wrote NetCDF:" in out
+    assert "Wrote NetCDF: " + str(tmp_path / "xsection_20_2500.nc") in out
+    assert "Wrote NetCDF: " + str(tmp_path / "xsection_2500_10000.nc") in out
     assert out.count("Broadening: requested=self:1.000 -> effective=self:1.000") == 2
 
 
@@ -263,6 +319,37 @@ def test_cli_xsection_composition_writes_one_file_with_component_fields(monkeypa
     ]
     out = capsys.readouterr().out
     assert "Wrote NetCDF:" in out
+
+
+def test_cli_xsection_uses_output_dir_for_generated_path(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pyharp-dump",
+            "xsection",
+            "--species",
+            "H2O",
+            "--wn-range=20,2500",
+            "--output-dir",
+            str(tmp_path / "products"),
+        ],
+    )
+    monkeypatch.setattr(
+        "pyharp.spectra.dump_cli._compute_species_xsection",
+        lambda args: (type("Spectrum", (), {})(), None, None),
+    )
+    written = []
+    monkeypatch.setattr(
+        "pyharp.spectra.dump_cli._write_xsection_dataset",
+        lambda spectrum, output_path, **kwargs: written.append(output_path),
+    )
+
+    main()
+
+    assert written == [tmp_path / "products" / "h2o_xsection_300K_1bar_20_2500.nc"]
+    out = capsys.readouterr().out
+    assert "Wrote NetCDF: " + str(tmp_path / "products" / "h2o_xsection_300K_1bar_20_2500.nc") in out
 
 
 def test_combine_band_datasets_preserves_band_metadata() -> None:
@@ -325,6 +412,7 @@ def test_xsection_dataset_keeps_only_sigma_fields() -> None:
         spectrum,
         species_name="H2O",
         secondary_component={"kind": "continuum", "label": "H2O continuum (MT_CKD)"},
+        wn_range=(20.0, 22.0),
     )
     try:
         assert set(dataset.data_vars) == {
@@ -332,6 +420,8 @@ def test_xsection_dataset_keeps_only_sigma_fields() -> None:
             "sigma_continuum_h2o_continuum_mt_ckd",
             "sigma_total",
         }
+        assert dataset.attrs["band_wavenumber_min_cm1"] == 20.0
+        assert dataset.attrs["band_wavenumber_max_cm1"] == 22.0
     finally:
         dataset.close()
 
@@ -401,6 +491,8 @@ def test_pair_xsection_dataset_uses_binary_absorption_units(monkeypatch, tmp_pat
         assert dataset["binary_absorption_coefficient"].attrs["units"] == "cm^5 molecule^-2"
         assert "binary absorption coefficient" in dataset["binary_absorption_coefficient"].attrs["long_name"].lower()
         assert dataset.attrs["pair_name"] == "H2-He"
+        assert dataset.attrs["band_wavenumber_min_cm1"] == 20.0
+        assert dataset.attrs["band_wavenumber_max_cm1"] == 22.0
     finally:
         dataset.close()
 
@@ -463,6 +555,8 @@ def test_composition_xsection_dataset_uses_one_field_per_species_or_cia(monkeypa
             "binary_absorption_coefficient_h2_he",
         }
         assert dataset.attrs["species_name"] == "H2,He,H2O"
+        assert dataset.attrs["band_wavenumber_min_cm1"] == 20.0
+        assert dataset.attrs["band_wavenumber_max_cm1"] == 21.0
         assert dataset["sigma_line_h2o"].attrs["units"] == "cm^2 molecule^-1"
         assert np.allclose(dataset["sigma_line_h2o"].values, np.array([3.0, 4.0]))
         assert dataset["sigma_continuum_h2o_continuum_mt_ckd"].attrs["units"] == "cm^2 molecule^-1"
@@ -507,16 +601,20 @@ def test_cli_xsection_composition_multi_range_uses_composition_worker(monkeypatc
         ],
     )
     monkeypatch.setattr(
-        "pyharp.spectra.dump_cli._write_combined_dataset",
-        lambda datasets, *, wn_ranges, output_path: written.append((len(datasets), wn_ranges, output_path)),
+        "pyharp.spectra.dump_cli.write_dataset_via_tmp",
+        lambda dataset, output_path, *, engine: written.append((tuple(dataset["wavenumber"].values), output_path, engine)),
     )
 
     main()
 
     assert worker_calls == [("composition", (20.0, 2500.0)), ("composition", (2500.0, 10000.0))]
-    assert written == [(2, [(20.0, 2500.0), (2500.0, 10000.0)], tmp_path / "mixture.nc")]
+    assert written == [
+        ((20.0, 21.0), tmp_path / "mixture_20_2500.nc", "scipy"),
+        ((20.0, 21.0), tmp_path / "mixture_2500_10000.nc", "scipy"),
+    ]
     out = capsys.readouterr().out
-    assert "Wrote NetCDF:" in out
+    assert "Wrote NetCDF: " + str(tmp_path / "mixture_20_2500.nc") in out
+    assert "Wrote NetCDF: " + str(tmp_path / "mixture_2500_10000.nc") in out
 
 
 def test_species_transmission_dataset_matches_xsection_naming() -> None:
@@ -555,6 +653,7 @@ def test_species_transmission_dataset_matches_xsection_naming() -> None:
         transmittance=transmittance,
         species_name="H2O",
         secondary_component={"kind": "continuum", "label": "H2O continuum (MT_CKD)"},
+        wn_range=(20.0, 22.0),
     )
     try:
         assert set(dataset.data_vars) == {
@@ -566,6 +665,8 @@ def test_species_transmission_dataset_matches_xsection_naming() -> None:
             "attenuation_total",
         }
         assert dataset.attrs["species_name"] == "H2O"
+        assert dataset.attrs["band_wavenumber_min_cm1"] == 20.0
+        assert dataset.attrs["band_wavenumber_max_cm1"] == 22.0
         assert dataset["attenuation_continuum_h2o_continuum_mt_ckd"].attrs["units"] == "m^-1"
     finally:
         dataset.close()
@@ -625,8 +726,8 @@ def test_composition_transmission_dataset_uses_component_names_and_attrs(monkeyp
             "transmission",
             "--composition",
             "H2:0.9,He:0.1,H2O:0.002",
-            "--path-length-m",
-            "2",
+            "--path-length-km",
+            "0.002",
             "--wn-range",
             "20,21",
             "--hitran-dir",
@@ -638,6 +739,8 @@ def test_composition_transmission_dataset_uses_component_names_and_attrs(monkeyp
     try:
         assert dataset.attrs["composition_input"] == "H2:0.9,He:0.1,H2O:0.002"
         assert dataset.attrs["species_name"] == "H2,He,H2O"
+        assert dataset.attrs["band_wavenumber_min_cm1"] == 20.0
+        assert dataset.attrs["band_wavenumber_max_cm1"] == 21.0
         assert set(dataset.data_vars) == {
             "transmittance_total",
             "attenuation_total",
@@ -651,6 +754,81 @@ def test_composition_transmission_dataset_uses_component_names_and_attrs(monkeyp
         assert np.allclose(dataset["attenuation_line_h2o"].values, np.array([600.0, 800.0]))
         assert np.allclose(dataset["attenuation_continuum_h2o_continuum_mt_ckd"].values, np.array([5000.0, 6000.0]))
         assert np.allclose(dataset["attenuation_cia_h2_he"].values, np.array([7000.0, 8000.0]))
+    finally:
+        dataset.close()
+
+
+def test_composition_transmission_total_equals_product_of_weighted_components(monkeypatch, tmp_path) -> None:
+    products = type(
+        "Products",
+        (),
+        {
+            "spectrum": type(
+                "Spectrum",
+                (),
+                {
+                    "wavenumber_cm1": np.array([20.0, 21.0]),
+                    "attenuation_total_m1": np.array([18.0, 24.0]),
+                    "temperature_k": 300.0,
+                    "pressure_pa": 1.0e5,
+                    "number_density_cm3": 10.0,
+                },
+            )(),
+            "transmittance": type(
+                "Trans",
+                (),
+                {
+                    "wavenumber_cm1": np.array([20.0, 21.0]),
+                    "transmittance_total": np.exp(-2.0 * np.array([18.0, 24.0])),
+                    "path_length_m": 2.0,
+                    "temperature_k": 300.0,
+                    "pressure_pa": 1.0e5,
+                },
+            )(),
+            "species_terms": (
+                type(
+                    "SpeciesTerm",
+                    (),
+                    {"species_name": "H2O", "mole_fraction": 0.2, "sigma_line_cm2_molecule": np.array([3.0, 4.0])},
+                )(),
+            ),
+            "secondary_sources": (
+                type(
+                    "Secondary",
+                    (),
+                    {"kind": "continuum", "label": "H2O continuum (MT_CKD)", "sigma_cm2_molecule": np.array([5.0, 6.0])},
+                )(),
+                type(
+                    "Secondary",
+                    (),
+                    {"kind": "binary_cia", "label": "H2-He", "sigma_cm2_molecule": np.array([7.0, 8.0])},
+                )(),
+            ),
+        },
+    )()
+    monkeypatch.setattr("pyharp.spectra.dump_cli._compute_composition_products", lambda args: products)
+    args = build_parser().parse_args(
+        [
+            "transmission",
+            "--composition",
+            "H2:0.9,He:0.1,H2O:0.002",
+            "--path-length-km",
+            "0.002",
+            "--wn-range",
+            "20,21",
+            "--hitran-dir",
+            str(tmp_path / "hitran"),
+        ]
+    )
+
+    dataset = _composition_transmission_dataset(_args_for_wn_range(args, args.wn_ranges[0]))
+    try:
+        component_product = (
+            dataset["transmittance_line_h2o"].values
+            * dataset["transmittance_continuum_h2o_continuum_mt_ckd"].values
+            * dataset["transmittance_cia_h2_he"].values
+        )
+        assert np.allclose(component_product, dataset["transmittance_total"].values)
     finally:
         dataset.close()
 
@@ -753,5 +931,7 @@ def test_cli_transmission_help_describes_broadening_and_path_length(capsys) -> N
     help_text = capsys.readouterr().out
     assert "Compute line, CIA, and total transmission over a fixed path length and write a NetCDF dataset." in help_text
     assert "--broadening-composition BROADENER:FRACTION,..." in help_text
-    assert "Propagation path length in meters." in help_text
+    assert "Transmission path length in kilometers." in help_text
+    assert "Output NetCDF path. Defaults to an auto-generated path" in help_text
+    assert "under --output-dir." in help_text
     assert "pyharp-dump transmission --composition H2:0.9,He:0.1,CH4:0.004" in help_text

--- a/tests/spectra/test_cli.py
+++ b/tests/spectra/test_cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import xarray as xr
 
 from pyharp.spectra.dataset_io import combine_band_datasets, write_dataset_via_tmp
-from pyharp.spectra.dump_cli import _args_for_wn_range, _composition_transmission_dataset, _composition_xsection_dataset, _output_path_for_wn_range, _pair_xsection_dataset, _species_transmission_dataset, _xsection_dataset, build_parser, main
+from pyharp.spectra.dump_cli import _args_for_wn_range, _composition_transmission_dataset, _composition_xsection_dataset, _output_path_for_wn_range, _pair_xsection_dataset, _species_transmission_dataset, _stack_temperature_datasets, _xsection_dataset, build_parser, main
 from pyharp.spectra.shared_cli import default_hitran_dir, default_output_path, project_root
 from pyharp.spectra.spectrum import AbsorptionSpectrum
 
@@ -14,7 +14,7 @@ from pyharp.spectra.spectrum import AbsorptionSpectrum
 def test_default_paths_are_inside_project_root() -> None:
     root = project_root()
     assert default_output_path().is_relative_to(root)
-    assert default_output_path().name == "co2_xsection_300K_1bar_20_2500.nc"
+    assert default_output_path().name == "co2_xsection_1bar_300K_20_2500cm1.nc"
     assert default_output_path().parent.name == "output"
     assert default_hitran_dir() == default_hitran_dir().parent / "hitran"
     assert default_hitran_dir().is_absolute() is False
@@ -51,7 +51,7 @@ def test_xsection_parser_accepts_species_pressure_temperature_and_outputs(tmp_pa
     assert args.command == "xsection"
     assert args.output == tmp_path / "xsection.nc"
     assert args.output_dir == tmp_path / "named"
-    assert args.temperature_k == 300.0
+    assert args.temperature_k == [300.0]
     assert args.pressure_bar == 1.0
     assert args.species == "co2"
     assert args.broadening_composition == "air:0.8,self:0.2"
@@ -79,7 +79,7 @@ def test_xsection_parser_accepts_cia_pair_selector(tmp_path) -> None:
     )
     assert args.command == "xsection"
     assert args.output == tmp_path / "pair.nc"
-    assert args.temperature_k == 300.0
+    assert args.temperature_k == [300.0]
     assert args.pressure_bar == 1.0
     assert args.pair == "H2-He"
     assert args.filename == "H2-He_2011.cia"
@@ -109,7 +109,7 @@ def test_transmission_parser_accepts_path_length_and_outputs(tmp_path) -> None:
     )
     assert args.command == "transmission"
     assert args.output == tmp_path / "trans.nc"
-    assert args.temperature_k == 300.0
+    assert args.temperature_k == [300.0]
     assert args.pressure_bar == 1.0
     assert args.path_length_km == 1.5
     assert args.species == "CO2"
@@ -149,6 +149,23 @@ def test_xsection_parser_accepts_repeated_wn_ranges(tmp_path) -> None:
     assert args.wn_ranges == [(20.0, 2500.0), (2500.0, 10000.0)]
 
 
+def test_xsection_parser_accepts_temperature_list(tmp_path) -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "xsection",
+            "--species",
+            "H2O",
+            "--temperature-k",
+            "300,400,500",
+            "--output",
+            str(tmp_path / "xsection.nc"),
+        ]
+    )
+
+    assert args.temperature_k == [300.0, 400.0, 500.0]
+
+
 def test_output_path_for_multiple_ranges_appends_band_suffix(tmp_path) -> None:
     parser = build_parser()
     args = parser.parse_args(
@@ -180,7 +197,25 @@ def test_output_path_for_wn_range_uses_output_dir_for_generated_names(tmp_path) 
         ]
     )
 
-    assert _output_path_for_wn_range(args, wn_range=(20.0, 2500.0), suffix=".nc") == tmp_path / "products" / "h2o_xsection_300K_1bar_20_2500.nc"
+    assert _output_path_for_wn_range(args, wn_range=(20.0, 2500.0), suffix=".nc") == tmp_path / "products" / "h2o_xsection_1bar_300K_20_2500cm1.nc"
+
+
+def test_output_path_for_wn_range_includes_temperature_list_token(tmp_path) -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "xsection",
+            "--species",
+            "H2O",
+            "--temperature-k",
+            "300,400,500",
+            "--wn-range=20,2500",
+            "--output-dir",
+            str(tmp_path / "products"),
+        ]
+    )
+
+    assert _output_path_for_wn_range(args, wn_range=(20.0, 2500.0), suffix=".nc") == tmp_path / "products" / "h2o_xsection_1bar_300_400_500K_20_2500cm1.nc"
 
 
 def test_cli_xsection_reports_broadening_summary(monkeypatch, tmp_path, capsys) -> None:
@@ -215,7 +250,8 @@ def test_cli_xsection_reports_broadening_summary(monkeypatch, tmp_path, capsys) 
         "pyharp.spectra.dump_cli.compute_absorption_spectrum_from_sources",
         lambda **kwargs: type("Spectrum", (), {})(),
     )
-    monkeypatch.setattr("pyharp.spectra.dump_cli._write_xsection_dataset", lambda spectrum, output_path, **kwargs: None)
+    monkeypatch.setattr("pyharp.spectra.dump_cli._compute_xsection_band", lambda task: (xr.Dataset(), "requested=h2:0.900,he:0.100 -> effective=air:1.000 (fallback: h2->air, he->air)"))
+    monkeypatch.setattr("pyharp.spectra.dump_cli.write_dataset_via_tmp", lambda dataset, output_path, *, engine: None)
 
     main()
 
@@ -239,21 +275,20 @@ def test_cli_xsection_writes_one_file_per_range(monkeypatch, tmp_path, capsys) -
             str(tmp_path / "xsection.nc"),
         ],
     )
-    calls = []
     written = []
     monkeypatch.setattr(
-        "pyharp.spectra.dump_cli._parallel_band_results",
-        lambda tasks, *, worker: [
-            (
-                calls.append(task_args.wn_range)
-                or xr.Dataset(
+        "pyharp.spectra.dump_cli._compute_xsection_band",
+        lambda task: (
+            xr.Dataset(
                 coords={"wavenumber": ("wavenumber", np.array([1.0, 2.0]))},
-                    data_vars={"sigma_total": ("wavenumber", np.array([3.0, 4.0]))},
-                ),
-                "requested=self:1.000 -> effective=self:1.000",
-            )
-            for _, task_args in tasks
-        ],
+                data_vars={"sigma_total": ("wavenumber", np.array([3.0, 4.0]))},
+            ),
+            "requested=self:1.000 -> effective=self:1.000",
+        ),
+    )
+    monkeypatch.setattr(
+        "pyharp.spectra.dump_cli._parallel_band_results",
+        lambda tasks, *, worker: [worker(task) for task in tasks],
     )
     monkeypatch.setattr(
         "pyharp.spectra.dump_cli.write_dataset_via_tmp",
@@ -262,7 +297,6 @@ def test_cli_xsection_writes_one_file_per_range(monkeypatch, tmp_path, capsys) -
 
     main()
 
-    assert calls == [(20.0, 2500.0), (2500.0, 10000.0)]
     assert written == [
         ((1.0, 2.0), tmp_path / "xsection_20_2500.nc", "scipy"),
         ((1.0, 2.0), tmp_path / "xsection_2500_10000.nc", "scipy"),
@@ -304,8 +338,12 @@ def test_cli_xsection_composition_writes_one_file_with_component_fields(monkeypa
         ),
     )
     monkeypatch.setattr(
+        "pyharp.spectra.dump_cli._parallel_band_results",
+        lambda tasks, *, worker: [worker(task) for task in tasks],
+    )
+    monkeypatch.setattr(
         "pyharp.spectra.dump_cli.write_dataset_via_tmp",
-        lambda dataset, output_path, *, engine: written.append((sorted(dataset.data_vars), output_path, engine)),
+        lambda dataset, output_path, *, engine: written.append((sorted(dataset.data_vars), dataset["sigma_total"].dims, tuple(dataset["temperature"].values), output_path, engine)),
     )
 
     main()
@@ -313,6 +351,8 @@ def test_cli_xsection_composition_writes_one_file_with_component_fields(monkeypa
     assert written == [
         (
             ["binary_absorption_coefficient_h2_he", "sigma_line_h2", "sigma_total"],
+            ("temperature", "wavenumber"),
+            (300.0,),
             tmp_path / "mixture.nc",
             "scipy",
         )
@@ -335,21 +375,144 @@ def test_cli_xsection_uses_output_dir_for_generated_path(monkeypatch, tmp_path, 
             str(tmp_path / "products"),
         ],
     )
-    monkeypatch.setattr(
-        "pyharp.spectra.dump_cli._compute_species_xsection",
-        lambda args: (type("Spectrum", (), {})(), None, None),
-    )
     written = []
     monkeypatch.setattr(
-        "pyharp.spectra.dump_cli._write_xsection_dataset",
-        lambda spectrum, output_path, **kwargs: written.append(output_path),
+        "pyharp.spectra.dump_cli._compute_xsection_band",
+        lambda task: (xr.Dataset(), None),
+    )
+    monkeypatch.setattr(
+        "pyharp.spectra.dump_cli.write_dataset_via_tmp",
+        lambda dataset, output_path, *, engine: written.append(output_path),
     )
 
     main()
 
-    assert written == [tmp_path / "products" / "h2o_xsection_300K_1bar_20_2500.nc"]
+    assert written == [tmp_path / "products" / "h2o_xsection_1bar_300K_20_2500cm1.nc"]
     out = capsys.readouterr().out
-    assert "Wrote NetCDF: " + str(tmp_path / "products" / "h2o_xsection_300K_1bar_20_2500.nc") in out
+    assert "Wrote NetCDF: " + str(tmp_path / "products" / "h2o_xsection_1bar_300K_20_2500cm1.nc") in out
+
+
+def test_stack_temperature_datasets_adds_temperature_dimension() -> None:
+    first = xr.Dataset(
+        coords={"wavenumber": ("wavenumber", np.array([20.0, 21.0]))},
+        data_vars={"sigma_total": ("wavenumber", np.array([1.0, 2.0]))},
+        attrs={"species_name": "H2O", "temperature_k": 300.0, "pressure_pa": 1.0e5, "number_density_cm3": 1.0},
+    )
+    second = xr.Dataset(
+        coords={"wavenumber": ("wavenumber", np.array([20.0, 21.0]))},
+        data_vars={"sigma_total": ("wavenumber", np.array([3.0, 4.0]))},
+        attrs={"species_name": "H2O", "temperature_k": 400.0, "pressure_pa": 1.0e5, "number_density_cm3": 2.0},
+    )
+
+    stacked = _stack_temperature_datasets([first, second], temperatures=[300.0, 400.0])
+    try:
+        assert stacked["sigma_total"].dims == ("temperature", "wavenumber")
+        assert np.allclose(stacked["temperature"].values, np.array([300.0, 400.0]))
+        assert stacked["temperature"].attrs["units"] == "K"
+        assert "temperature_k" not in stacked.attrs
+        assert "number_density_cm3" not in stacked.attrs
+    finally:
+        stacked.close()
+        first.close()
+        second.close()
+
+
+def test_cli_xsection_temperature_list_writes_temperature_stacked_dataset(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pyharp-dump",
+            "xsection",
+            "--species",
+            "H2O",
+            "--temperature-k",
+            "300,400",
+            "--wn-range",
+            "20,22",
+            "--output",
+            str(tmp_path / "xsection.nc"),
+        ],
+    )
+    monkeypatch.setattr(
+        "pyharp.spectra.dump_cli._parallel_band_results",
+        lambda tasks, *, worker: [
+            (
+                xr.Dataset(
+                    coords={"wavenumber": ("wavenumber", np.array([20.0, 21.0]))},
+                    data_vars={"sigma_total": ("wavenumber", np.array([float(task_args.temperature_k), float(task_args.temperature_k) + 1.0]))},
+                    attrs={"species_name": "H2O", "temperature_k": float(task_args.temperature_k), "pressure_pa": 1.0e5},
+                ),
+                "requested=self:1.000 -> effective=self:1.000",
+            )
+            for _, task_args in tasks
+        ],
+    )
+    written = []
+    monkeypatch.setattr(
+        "pyharp.spectra.dump_cli.write_dataset_via_tmp",
+        lambda dataset, output_path, *, engine: written.append((dataset["sigma_total"].dims, tuple(dataset["temperature"].values), output_path, engine)),
+    )
+
+    main()
+
+    assert written == [
+        (("temperature", "wavenumber"), (300.0, 400.0), tmp_path / "xsection.nc", "scipy")
+    ]
+    out = capsys.readouterr().out
+    assert "Wrote NetCDF: " + str(tmp_path / "xsection.nc") in out
+
+
+def test_cli_xsection_temperature_list_and_ranges_flattens_all_tasks(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pyharp-dump",
+            "xsection",
+            "--species",
+            "H2O",
+            "--temperature-k",
+            "300,400,500",
+            "--wn-range=20,2500",
+            "--wn-range=2500,10000",
+            "--output",
+            str(tmp_path / "xsection.nc"),
+        ],
+    )
+    seen = []
+
+    def fake_parallel(tasks, *, worker):
+        for _, task_args in tasks:
+            seen.append((task_args.wn_range, float(task_args.temperature_k)))
+        return [
+            (
+                xr.Dataset(
+                    coords={"wavenumber": ("wavenumber", np.array([1.0, 2.0]))},
+                    data_vars={"sigma_total": ("wavenumber", np.array([3.0, 4.0]))},
+                    attrs={"species_name": "H2O", "pressure_pa": 1.0e5},
+                ),
+                None,
+            )
+            for _ in tasks
+        ]
+
+    monkeypatch.setattr("pyharp.spectra.dump_cli._parallel_band_results", fake_parallel)
+    monkeypatch.setattr("pyharp.spectra.dump_cli.write_dataset_via_tmp", lambda dataset, output_path, *, engine: None)
+
+    main()
+
+    assert seen == [
+        ((20.0, 2500.0), 300.0),
+        ((20.0, 2500.0), 400.0),
+        ((20.0, 2500.0), 500.0),
+        ((2500.0, 10000.0), 300.0),
+        ((2500.0, 10000.0), 400.0),
+        ((2500.0, 10000.0), 500.0),
+    ]
+    out = capsys.readouterr().out
+    assert "Wrote NetCDF: " + str(tmp_path / "xsection_20_2500.nc") in out
+    assert "Wrote NetCDF: " + str(tmp_path / "xsection_2500_10000.nc") in out
 
 
 def test_combine_band_datasets_preserves_band_metadata() -> None:
@@ -583,22 +746,21 @@ def test_cli_xsection_composition_multi_range_uses_composition_worker(monkeypatc
             str(tmp_path / "mixture.nc"),
         ],
     )
-    worker_calls = []
     written = []
 
     monkeypatch.setattr(
+        "pyharp.spectra.dump_cli._compute_xsection_band",
+        lambda task: (
+            xr.Dataset(
+                coords={"wavenumber": ("wavenumber", np.array([20.0, 21.0]))},
+                data_vars={"sigma_total": ("wavenumber", np.array([1.0, 2.0]))},
+            ),
+            None,
+        ),
+    )
+    monkeypatch.setattr(
         "pyharp.spectra.dump_cli._parallel_band_results",
-        lambda tasks, *, worker: [
-            (
-                worker_calls.append((target_kind, task_args.wn_range))
-                or xr.Dataset(
-                    coords={"wavenumber": ("wavenumber", np.array([20.0, 21.0]))},
-                    data_vars={"sigma_total": ("wavenumber", np.array([1.0, 2.0]))},
-                ),
-                None,
-            )
-            for target_kind, task_args in tasks
-        ],
+        lambda tasks, *, worker: [worker(task) for task in tasks],
     )
     monkeypatch.setattr(
         "pyharp.spectra.dump_cli.write_dataset_via_tmp",
@@ -607,7 +769,6 @@ def test_cli_xsection_composition_multi_range_uses_composition_worker(monkeypatc
 
     main()
 
-    assert worker_calls == [("composition", (20.0, 2500.0)), ("composition", (2500.0, 10000.0))]
     assert written == [
         ((20.0, 21.0), tmp_path / "mixture_20_2500.nc", "scipy"),
         ((20.0, 21.0), tmp_path / "mixture_2500_10000.nc", "scipy"),

--- a/tests/spectra/test_cli.py
+++ b/tests/spectra/test_cli.py
@@ -184,6 +184,24 @@ def test_output_path_for_multiple_ranges_appends_band_suffix(tmp_path) -> None:
     assert _output_path_for_wn_range(args, wn_range=(2500.0, 10000.0), suffix=".nc") == tmp_path / "xsection_2500_10000.nc"
 
 
+def test_output_path_for_multiple_ranges_normalizes_suffix_tokens(tmp_path) -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "xsection",
+            "--species",
+            "H2O",
+            "--wn-range=-1,30.5",
+            "--wn-range=30.5,100",
+            "--output",
+            str(tmp_path / "xsection.nc"),
+        ]
+    )
+
+    assert _output_path_for_wn_range(args, wn_range=(-1.0, 30.5), suffix=".nc") == tmp_path / "xsection_m1_30p5.nc"
+    assert _output_path_for_wn_range(args, wn_range=(30.5, 100.0), suffix=".nc") == tmp_path / "xsection_30p5_100.nc"
+
+
 def test_output_path_for_wn_range_uses_output_dir_for_generated_names(tmp_path) -> None:
     parser = build_parser()
     args = parser.parse_args(

--- a/tests/spectra/test_output_names.py
+++ b/tests/spectra/test_output_names.py
@@ -13,7 +13,7 @@ def test_default_output_path_uses_requested_pattern() -> None:
         suffix=".png",
     )
 
-    assert path == Path("output/co2_xsection_300K_1bar_20_2500.png")
+    assert path == Path("output/co2_xsection_1bar_300K_20_2500cm1.png")
 
 
 def test_default_output_path_sanitizes_cia_and_composition_names() -> None:
@@ -34,5 +34,5 @@ def test_default_output_path_sanitizes_cia_and_composition_names() -> None:
         suffix=".pdf",
     )
 
-    assert cia_path == Path("output/h2_he_attenuation_275p5K_0p25bar_25_30p5.png")
-    assert composition_path == Path("output/h2o_0p1_h2_0p9_overview_300K_1bar_25_2500.pdf")
+    assert cia_path == Path("output/h2_he_attenuation_0p25bar_275p5K_25_30p5cm1.png")
+    assert composition_path == Path("output/h2o_0p1_h2_0p9_overview_1bar_300K_25_2500cm1.pdf")

--- a/tests/spectra/test_plot_cli.py
+++ b/tests/spectra/test_plot_cli.py
@@ -96,7 +96,7 @@ def test_plot_main_dispatches_pair_attenuation(monkeypatch) -> None:
     assert len(calls) == 1
     assert calls[0].pair == "H2-He"
     assert calls[0].wn_range == (25.0, 30.0)
-    assert calls[0].figure.name == "h2_he_attenuation_300K_1bar_25_30.png"
+    assert calls[0].figure.name == "h2_he_attenuation_1bar_300K_25_30cm1.png"
 
 
 def test_plot_main_dispatches_molecule_xsection_with_default_figure(monkeypatch) -> None:
@@ -110,7 +110,7 @@ def test_plot_main_dispatches_molecule_xsection_with_default_figure(monkeypatch)
     plot_cli.main(["xsection", "--species", "CO2", "--temperature-k", "275.5", "--pressure-bar", "0.25", "--wn-range", "25,30.5"])
 
     assert len(calls) == 1
-    assert calls[0].figure.name == "co2_xsection_275p5K_0p25bar_25_30p5.png"
+    assert calls[0].figure.name == "co2_xsection_0p25bar_275p5K_25_30p5cm1.png"
 
 
 def test_plot_main_uses_output_dir_for_default_figure(monkeypatch, tmp_path) -> None:
@@ -138,7 +138,7 @@ def test_plot_main_uses_output_dir_for_default_figure(monkeypatch, tmp_path) -> 
     )
 
     assert len(calls) == 1
-    assert calls[0].figure == tmp_path / "figures" / "co2_xsection_275p5K_0p25bar_25_30p5.png"
+    assert calls[0].figure == tmp_path / "figures" / "co2_xsection_0p25bar_275p5K_25_30p5cm1.png"
 
 
 def test_plot_main_passes_broadening_composition_to_molecule_workflow(monkeypatch) -> None:
@@ -166,7 +166,7 @@ def test_plot_main_dispatches_composition_attenuation(monkeypatch) -> None:
 
     assert len(calls) == 1
     assert calls[0][0].composition == "H2:0.9,He:0.1"
-    assert calls[0][0].figure.name == "h2_0p9_he_0p1_attenuation_300K_1bar_25_30.png"
+    assert calls[0][0].figure.name == "h2_0p9_he_0p1_attenuation_1bar_300K_25_30cm1.png"
     assert calls[0][1] == (25.0, 30.0)
 
 

--- a/tests/spectra/test_plot_cli.py
+++ b/tests/spectra/test_plot_cli.py
@@ -1,6 +1,8 @@
+import numpy as np
 import pytest
 
 from pyharp.spectra import plot_cli
+from pyharp.spectra.dump_cli import _args_for_wn_range, _composition_transmission_dataset, build_parser as build_dump_parser
 
 
 def test_plot_parser_accepts_cia_binary_with_wn_range(tmp_path) -> None:
@@ -10,17 +12,20 @@ def test_plot_parser_accepts_cia_binary_with_wn_range(tmp_path) -> None:
             "binary",
             "--pair",
             "H2-H2",
+            "--output-dir",
+            str(tmp_path / "figures"),
             "--temperature-k",
             "300",
             "--wn-range",
             "20,10000",
-            "--figure",
+            "--output",
             str(tmp_path / "cia.png"),
         ]
     )
 
     assert args.command == "binary"
     assert args.pair == "H2-H2"
+    assert args.output_dir == tmp_path / "figures"
     assert args.wn_range == (20.0, 10000.0)
     assert args.figure == tmp_path / "cia.png"
 
@@ -40,7 +45,7 @@ def test_plot_parser_accepts_molecule_xsection_with_wn_range(tmp_path) -> None:
             "air:0.8,self:0.2",
             "--wn-range",
             "20,2500",
-            "--figure",
+            "--output",
             str(tmp_path / "co2.png"),
         ]
     )
@@ -65,7 +70,7 @@ def test_plot_parser_accepts_atm_overview_ranges(tmp_path) -> None:
             "--wn-range=2501,20000",
             "--manifest",
             str(tmp_path / "sources.json"),
-            "--figure",
+            "--output",
             str(tmp_path / "atm.pdf"),
         ]
     )
@@ -108,6 +113,34 @@ def test_plot_main_dispatches_molecule_xsection_with_default_figure(monkeypatch)
     assert calls[0].figure.name == "co2_xsection_275p5K_0p25bar_25_30p5.png"
 
 
+def test_plot_main_uses_output_dir_for_default_figure(monkeypatch, tmp_path) -> None:
+    calls = []
+
+    def fake_run(args):
+        calls.append(args)
+
+    monkeypatch.setattr("pyharp.spectra.plot_cli.molecule_plot_cli.run_xsection", fake_run)
+
+    plot_cli.main(
+        [
+            "xsection",
+            "--species",
+            "CO2",
+            "--temperature-k",
+            "275.5",
+            "--pressure-bar",
+            "0.25",
+            "--wn-range",
+            "25,30.5",
+            "--output-dir",
+            str(tmp_path / "figures"),
+        ]
+    )
+
+    assert len(calls) == 1
+    assert calls[0].figure == tmp_path / "figures" / "co2_xsection_275p5K_0p25bar_25_30p5.png"
+
+
 def test_plot_main_passes_broadening_composition_to_molecule_workflow(monkeypatch) -> None:
     calls = []
 
@@ -137,6 +170,127 @@ def test_plot_main_dispatches_composition_attenuation(monkeypatch) -> None:
     assert calls[0][1] == (25.0, 30.0)
 
 
+def test_plot_main_preserves_explicit_figure_over_output_dir(monkeypatch, tmp_path) -> None:
+    calls = []
+
+    def fake_run(args):
+        calls.append(args)
+
+    monkeypatch.setattr("pyharp.spectra.plot_cli.cia_plot_cli.run_binary", fake_run)
+
+    plot_cli.main(
+        [
+            "binary",
+            "--pair",
+            "H2-He",
+            "--output-dir",
+            str(tmp_path / "figures"),
+            "--output",
+            str(tmp_path / "custom.png"),
+        ]
+    )
+
+    assert len(calls) == 1
+    assert calls[0].figure == tmp_path / "custom.png"
+
+
+def test_plot_composition_transmission_matches_dump_total(monkeypatch, tmp_path) -> None:
+    products = type(
+        "Products",
+        (),
+        {
+            "spectrum": type(
+                "Spectrum",
+                (),
+                {
+                    "wavenumber_cm1": np.array([20.0, 21.0]),
+                    "attenuation_total_m1": np.array([18.0, 24.0]),
+                    "temperature_k": 300.0,
+                    "pressure_pa": 1.0e5,
+                    "number_density_cm3": 10.0,
+                },
+            )(),
+            "transmittance": type(
+                "Trans",
+                (),
+                {
+                    "wavenumber_cm1": np.array([20.0, 21.0]),
+                    "transmittance_total": np.exp(-2.0 * np.array([18.0, 24.0])),
+                    "path_length_m": 2.0,
+                    "temperature_k": 300.0,
+                    "pressure_pa": 1.0e5,
+                },
+            )(),
+            "species_terms": (
+                type(
+                    "SpeciesTerm",
+                    (),
+                    {"species_name": "H2O", "mole_fraction": 0.2, "sigma_line_cm2_molecule": np.array([3.0, 4.0])},
+                )(),
+            ),
+            "secondary_sources": (
+                type(
+                    "Secondary",
+                    (),
+                    {"kind": "continuum", "label": "H2O continuum (MT_CKD)", "sigma_cm2_molecule": np.array([5.0, 6.0])},
+                )(),
+                type(
+                    "Secondary",
+                    (),
+                    {"kind": "binary_cia", "label": "H2-He", "sigma_cm2_molecule": np.array([7.0, 8.0])},
+                )(),
+            ),
+        },
+    )()
+    monkeypatch.setattr("pyharp.spectra.dump_cli._compute_composition_products", lambda args: products)
+    calls = []
+
+    def fake_run(args, *, wn_range):
+        calls.append((args, wn_range))
+
+    monkeypatch.setattr("pyharp.spectra.plot_cli.atm_overview_cli.run_atm_transmission", fake_run)
+
+    composition = "H2:0.9,He:0.1,H2O:0.002"
+    plot_cli.main(
+        [
+            "transmission",
+            "--composition",
+            composition,
+            "--path-length-km",
+            "0.002",
+            "--wn-range",
+            "20,21",
+            "--output",
+            str(tmp_path / "mixture.png"),
+        ]
+    )
+
+    dump_args = build_dump_parser().parse_args(
+        [
+            "transmission",
+            "--composition",
+            composition,
+            "--path-length-km",
+            "0.002",
+            "--wn-range",
+            "20,21",
+            "--output",
+            str(tmp_path / "mixture.nc"),
+        ]
+    )
+
+    dataset = _composition_transmission_dataset(_args_for_wn_range(dump_args, dump_args.wn_ranges[0]))
+    try:
+        assert np.allclose(dataset["transmittance_total"].values, products.transmittance.transmittance_total)
+    finally:
+        dataset.close()
+
+    assert len(calls) == 1
+    assert calls[0][0].composition == composition
+    assert calls[0][1] == (20.0, 21.0)
+    assert calls[0][0].path_length_km == 0.002
+
+
 def test_plot_main_rejects_multiple_selectors() -> None:
     with pytest.raises(SystemExit):
         plot_cli.main(["attenuation", "--pair", "H2-H2", "--species", "H2O"])
@@ -164,5 +318,5 @@ def test_plot_subcommand_help_describes_selectors_and_outputs(capsys) -> None:
     assert "--composition SPECIES:FRACTION,..." in help_text
     assert "Transmission path length in kilometers." in help_text
     assert "Output PNG path. Defaults to an auto-generated path" in help_text
-    assert "under output/." in help_text
+    assert "under --output-dir." in help_text
     assert "(default: None)" not in help_text


### PR DESCRIPTION
Unify pyharp-dump and pyharp-plot around --output and --output-dir, including consistent precedence where explicit output paths override auto-generated names rooted at --output-dir.

Change pyharp-dump transmission to use --path-length-km instead of --path-length-m, keep the default transmission path at 1 km, and convert to meters only at the computation boundary so dump and plot use the same user-facing unit.

Update pyharp-dump multi-range behavior to write one NetCDF per --wn-range, suffix explicit --output stems with the band bounds when multiple ranges are requested, and add global band_wavenumber_min_cm1 and band_wavenumber_max_cm1 attributes to single-band dump outputs.

Refresh README and Sphinx CLI docs and expand the dump/plot regression tests to cover output-dir handling, renamed flags, dump/plot composition transmission equivalence, weighted-component transmittance identity, default path lengths, and band-range metadata.