### PR TITLE
Add paired state grids to pyharp-plot overview workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ multi-page PDFs. These ranges are lower-inclusive and upper-exclusive. Use
 `--output` to choose the output path. Without `--output`, plots are written
 under `--output-dir` (default `output/`) with names derived from the target,
 plot type, pressure, temperature, and wavenumber range.
+For plot commands that use pressure, `--temperature-k` and `--pressure-bar`
+also accept matched comma-separated vectors such as
+`--temperature-k 300,400 --pressure-bar 1,10`. `pyharp-plot` then runs one
+plot per `(T,P)` pair in parallel. For `xsection`, `attenuation`, and
+`transmission`, one explicit `--output` path reused across multiple state
+pairs is expanded with `_<temperature>K_<pressure>bar` suffixes. For
+`overview`, all state/range pages are combined into one PDF.
 
 Molecular line calculations also accept `--broadening-composition BROADENER:FRACTION,...`,
 for example `air:0.8,self:0.2` or `H2:0.85,He:0.15`.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ for gas mixtures such as `H2O:0.1,H2:0.9`. All plot commands accept
 multi-page PDFs. These ranges are lower-inclusive and upper-exclusive. Use
 `--output` to choose the output path. Without `--output`, plots are written
 under `--output-dir` (default `output/`) with names derived from the target,
-plot type, pressure, temperature, and wavenumber range.
+plot type, temperature, pressure, and wavenumber range.
 For plot commands that use pressure, `--temperature-k` and `--pressure-bar`
 also accept matched comma-separated vectors such as
 `--temperature-k 300,400 --pressure-bar 1,10`. `pyharp-plot` then runs one

--- a/docs/source/plot_cli.rst
+++ b/docs/source/plot_cli.rst
@@ -22,9 +22,9 @@ Choose one subcommand, then choose the target data source with ``--pair``,
 
 Every command writes a figure. Use ``--output`` to select an explicit output
 path. Without ``--output``, plots are written under ``--output-dir`` using a
-name derived from the target, plot type, pressure, temperature, and
+name derived from the target, plot type, temperature, pressure, and
 wavenumber range, such as
-``output/co2_xsection_1bar_300K_20_2500cm1.png``.
+``output/co2_xsection_300K_1bar_20_2500cm1.png``.
 For subcommands that use pressure, ``--temperature-k`` and ``--pressure-bar``
 also accept matched comma-separated vectors such as ``300,400`` and ``1,10``.
 ``pyharp-plot`` runs one plot per ``(T,P)`` pair in parallel. For
@@ -213,8 +213,8 @@ Default filenames are normalized for shells and filesystems:
 .. code-block:: bash
 
    pyharp-plot xsection --species CO2 --temperature-k 275.5 --pressure-bar 0.25 --wn-range=25,30.5
-   # writes output/co2_xsection_0p25bar_275p5K_25_30p5cm1.png
+   # writes output/co2_xsection_275p5K_0p25bar_25_30p5cm1.png
 
    pyharp-plot overview --composition H2O:0.1,H2:0.9 --wn-range=25,2500
-   # writes output/h2o_0p1_h2_0p9_overview_1bar_300K_25_2500cm1.pdf
-   # also writes output/h2o_0p1_h2_0p9_overview_1bar_300K_25_2500cm1.manifest.json
+   # writes output/h2o_0p1_h2_0p9_overview_300K_1bar_25_2500cm1.pdf
+   # also writes output/h2o_0p1_h2_0p9_overview_300K_1bar_25_2500cm1.manifest.json

--- a/docs/source/plot_cli.rst
+++ b/docs/source/plot_cli.rst
@@ -25,6 +25,13 @@ path. Without ``--output``, plots are written under ``--output-dir`` using a
 name derived from the target, plot type, pressure, temperature, and
 wavenumber range, such as
 ``output/co2_xsection_1bar_300K_20_2500cm1.png``.
+For subcommands that use pressure, ``--temperature-k`` and ``--pressure-bar``
+also accept matched comma-separated vectors such as ``300,400`` and ``1,10``.
+``pyharp-plot`` runs one plot per ``(T,P)`` pair in parallel. For
+``xsection``, ``attenuation``, and ``transmission``, one explicit ``--output``
+path reused across multiple state pairs is expanded with
+``_<temperature>K_<pressure>bar`` suffixes. For ``overview``, all state/range
+pages are combined into one PDF.
 
 Subcommands
 -----------
@@ -43,8 +50,8 @@ uses a CIA pair selected by ``--pair``.
 ``xsection``
 ~~~~~~~~~~~~
 
-Plot a molecular absorption cross section at one pressure-temperature state.
-This subcommand uses a molecule selected by ``--species``.
+Plot a molecular absorption cross section. This subcommand uses a molecule
+selected by ``--species``.
 
 .. code-block:: bash
 
@@ -86,7 +93,9 @@ Generate a multi-panel PDF. With one species and one wavenumber range, the
 output is a single molecule overview. With multiple species or multiple
 ``--wn-range`` values, the output is a combined multi-page PDF. With
 ``--composition``, the output is an atmospheric mixture overview PDF and a
-manifest JSON file.
+manifest JSON file. When matched temperature/pressure vectors are provided,
+their pages are also folded into that same PDF rather than split into
+multiple PDFs.
 
 .. code-block:: bash
 
@@ -108,10 +117,13 @@ Shared Options
     Wavenumber grid spacing in ``cm^-1``. The default is ``1``.
 
 ``--temperature-k value``
-    Temperature in kelvin. The default is ``300``.
+    Temperature in kelvin. The default is ``300``. Use a comma-separated list
+    paired one-to-one with ``--pressure-bar`` to generate one plot per state
+    pair.
 
 ``--pressure-bar value``
     Pressure in bar. The default is ``1`` for subcommands that use pressure.
+    Use a comma-separated list paired one-to-one with ``--temperature-k``.
 
 ``--hitran-dir path``
     Directory used for downloaded HITRAN line and CIA data. The default is

--- a/python/spectra/atm_overview_cli.py
+++ b/python/spectra/atm_overview_cli.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 import json
+import multiprocessing as mp
 import os
 from pathlib import Path
 import tempfile
@@ -499,9 +501,33 @@ def _page_manifest(products: MixtureOverviewProducts) -> dict[str, object]:
         "wavenumber_max_cm1": products.band.wavenumber_max_cm1,
         "resolution_cm1": products.band.resolution_cm1,
         "grid_points": int(products.spectrum.wavenumber_cm1.size),
+        "temperature_k": float(products.spectrum.temperature_k),
+        "pressure_bar": float(products.spectrum.pressure_pa) / 1.0e5,
         "line_species": [term.species_name for term in products.species_terms],
         "opacity_sources": list(products.manifest_sources),
     }
+
+
+def _selected_temperatures(args: argparse.Namespace) -> list[float]:
+    values = getattr(args, "temperature_k", [300.0])
+    if isinstance(values, (list, tuple)):
+        return [float(value) for value in values]
+    return [float(values)]
+
+
+def _selected_pressure_bars(args: argparse.Namespace) -> list[float]:
+    values = getattr(args, "pressure_bar", [1.0])
+    if isinstance(values, (list, tuple)):
+        return [float(value) for value in values]
+    return [float(values)]
+
+
+def _state_pairs(args: argparse.Namespace) -> list[tuple[float, float]]:
+    temperatures = _selected_temperatures(args)
+    pressures = _selected_pressure_bars(args)
+    if len(temperatures) != len(pressures):
+        raise ValueError("temperature_k and pressure_bar must have the same number of values")
+    return list(zip(temperatures, pressures, strict=True))
 
 
 def build_atm_overview_parser() -> argparse.ArgumentParser:
@@ -533,22 +559,35 @@ def run_atm_overview(args: argparse.Namespace) -> None:
     figure_path.parent.mkdir(parents=True, exist_ok=True)
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
 
+    wn_ranges = list(args.wn_ranges)
+    state_pairs = _state_pairs(args)
+    tasks: list[tuple[argparse.Namespace, tuple[float, float]]] = []
+    page_metadata: list[tuple[float, float, tuple[float, float]]] = []
+    for temperature_k, pressure_bar in state_pairs:
+        state_args = argparse.Namespace(**vars(args))
+        state_args.temperature_k = float(temperature_k)
+        state_args.pressure_bar = float(pressure_bar)
+        for wn_range in wn_ranges:
+            tasks.append((state_args, wn_range))
+            page_metadata.append((float(temperature_k), float(pressure_bar), wn_range))
+    page_results = _parallel_mixture_overview_products(
+        tasks
+    )
     pages: list[dict[str, object]] = []
     with PdfPages(figure_path) as pdf:
-        for wn_range in args.wn_ranges:
-            products = compute_mixture_overview_products(args, wn_range=wn_range)
+        for (temperature_k, pressure_bar, wn_range), products in zip(page_metadata, page_results, strict=True):
             fig, axes = plt.subplots(nrows=4, ncols=1, figsize=(8.5, 11.0), squeeze=False)
             _render_mixture_overview(fig, axes[:, 0], products=products)
             pdf.savefig(fig)
             plt.close(fig)
             pages.append(_page_manifest(products))
-            print(f"Added page: {wn_range[0]:.3f}-{wn_range[1]:.3f} cm^-1")
+            print(f"Added page: T={temperature_k:.1f} K | p={pressure_bar:.3f} bar | {wn_range[0]:.3f}-{wn_range[1]:.3f} cm^-1")
 
     manifest = {
         "composition_input": str(args.composition),
         "composition_normalized": _parse_composition(args.composition),
-        "temperature_k": float(args.temperature_k),
-        "pressure_bar": float(args.pressure_bar),
+        "temperature_k": _selected_temperatures(args) if len(state_pairs) > 1 else float(state_pairs[0][0]),
+        "pressure_bar": _selected_pressure_bars(args) if len(state_pairs) > 1 else float(state_pairs[0][1]),
         "path_length_km": float(args.path_length_km),
         "figure_path": str(figure_path),
         "manifest_path": str(manifest_path),
@@ -559,3 +598,19 @@ def run_atm_overview(args: argparse.Namespace) -> None:
     print(f"Atmosphere overview figure: {figure_path}")
     print(f"Manifest: {manifest_path}")
     print(f"Pages: {len(pages)}")
+
+
+def _compute_mixture_overview_product_task(task: tuple[argparse.Namespace, tuple[float, float]]) -> MixtureOverviewProducts:
+    args, wn_range = task
+    return compute_mixture_overview_products(args, wn_range=wn_range)
+
+
+def _parallel_mixture_overview_products(
+    tasks: list[tuple[argparse.Namespace, tuple[float, float]]],
+) -> list[MixtureOverviewProducts]:
+    if len(tasks) <= 1:
+        return [_compute_mixture_overview_product_task(task) for task in tasks]
+    max_workers = min(len(tasks), os.cpu_count() or 1)
+    ctx = mp.get_context("fork")
+    with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as executor:
+        return list(executor.map(_compute_mixture_overview_product_task, tasks))

--- a/python/spectra/atm_overview_cli.py
+++ b/python/spectra/atm_overview_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterator
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 import json
@@ -570,12 +571,13 @@ def run_atm_overview(args: argparse.Namespace) -> None:
         for wn_range in wn_ranges:
             tasks.append((state_args, wn_range))
             page_metadata.append((float(temperature_k), float(pressure_bar), wn_range))
-    page_results = _parallel_mixture_overview_products(
-        tasks
-    )
     pages: list[dict[str, object]] = []
     with PdfPages(figure_path) as pdf:
-        for (temperature_k, pressure_bar, wn_range), products in zip(page_metadata, page_results, strict=True):
+        for (temperature_k, pressure_bar, wn_range), products in zip(
+            page_metadata,
+            _parallel_mixture_overview_products(tasks),
+            strict=True,
+        ):
             fig, axes = plt.subplots(nrows=4, ncols=1, figsize=(8.5, 11.0), squeeze=False)
             _render_mixture_overview(fig, axes[:, 0], products=products)
             pdf.savefig(fig)
@@ -586,8 +588,8 @@ def run_atm_overview(args: argparse.Namespace) -> None:
     manifest = {
         "composition_input": str(args.composition),
         "composition_normalized": _parse_composition(args.composition),
-        "temperature_k": _selected_temperatures(args) if len(state_pairs) > 1 else float(state_pairs[0][0]),
-        "pressure_bar": _selected_pressure_bars(args) if len(state_pairs) > 1 else float(state_pairs[0][1]),
+        "temperature_k": _selected_temperatures(args),
+        "pressure_bar": _selected_pressure_bars(args),
         "path_length_km": float(args.path_length_km),
         "figure_path": str(figure_path),
         "manifest_path": str(manifest_path),
@@ -607,10 +609,12 @@ def _compute_mixture_overview_product_task(task: tuple[argparse.Namespace, tuple
 
 def _parallel_mixture_overview_products(
     tasks: list[tuple[argparse.Namespace, tuple[float, float]]],
-) -> list[MixtureOverviewProducts]:
+) -> Iterator[MixtureOverviewProducts]:
     if len(tasks) <= 1:
-        return [_compute_mixture_overview_product_task(task) for task in tasks]
+        for task in tasks:
+            yield _compute_mixture_overview_product_task(task)
+        return
     max_workers = min(len(tasks), os.cpu_count() or 1)
     ctx = mp.get_context("fork")
     with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as executor:
-        return list(executor.map(_compute_mixture_overview_product_task, tasks))
+        yield from executor.map(_compute_mixture_overview_product_task, tasks)

--- a/python/spectra/dump_cli.py
+++ b/python/spectra/dump_cli.py
@@ -119,10 +119,10 @@ def _validate_single_selector(args: argparse.Namespace, parser: argparse.Argumen
 
 
 def _validate_state_grid(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
-    temperatures = _selected_base_temperatures(args)
-    pressures = _selected_pressure_bars(args)
-    if len(temperatures) != len(pressures):
-        parser.error("--temperature-k and --pressure-bar must have the same number of values")
+    try:
+        _state_pairs(args)
+    except ValueError as exc:
+        parser.error(str(exc))
 
 
 def _selected_target(args: argparse.Namespace) -> tuple[str, object]:
@@ -152,6 +152,19 @@ def _selected_del_temperatures(args: argparse.Namespace) -> list[float]:
     if isinstance(values, (list, tuple)):
         return [float(value) for value in values]
     return [float(values)]
+
+
+def _state_pairs(args: argparse.Namespace) -> list[tuple[float, float]]:
+    temperatures = _selected_base_temperatures(args)
+    pressures = _selected_pressure_bars(args)
+    if len(temperatures) != len(pressures):
+        raise ValueError("--temperature-k and --pressure-bar must have the same number of values")
+    return list(zip(temperatures, pressures, strict=True))
+
+
+def _single_base_state(args: argparse.Namespace) -> tuple[float, float]:
+    temperature_k, pressure_bar = _state_pairs(args)[0]
+    return float(temperature_k), float(pressure_bar)
 
 
 def _state_span_token(min_value: float, max_value: float, *, unit: str) -> str:
@@ -205,12 +218,6 @@ def _band_attr_values(wn_range: tuple[float, float]) -> dict[str, float]:
 def _args_for_wn_range(args: argparse.Namespace, wn_range: tuple[float, float]) -> argparse.Namespace:
     scoped = argparse.Namespace(**vars(args))
     scoped.wn_range = wn_range
-    return scoped
-
-
-def _args_for_temperature(args: argparse.Namespace, temperature_k: float) -> argparse.Namespace:
-    scoped = argparse.Namespace(**vars(args))
-    scoped.temperature_k = float(temperature_k)
     return scoped
 
 
@@ -623,8 +630,8 @@ def _compute_species_xsection(args: argparse.Namespace):
     line_provider = build_line_provider(config, line_db)
     cia_dataset = _resolve_species_cia(args, config)
     cia_selection = _resolve_species_cia_selection(args, config)
-    temperature_k = _selected_base_temperatures(args)[0]
-    pressure_pa = _selected_pressure_bars(args)[0] * 1.0e5
+    temperature_k, pressure_bar = _single_base_state(args)
+    pressure_pa = pressure_bar * 1.0e5
     grid = band.grid()
     cia_cross_section_cm2_molecule = None
     secondary_component: dict[str, object] | None = None
@@ -675,8 +682,8 @@ def _compute_pair_xsection(args: argparse.Namespace):
     spectrum = compute_absorption_spectrum_from_sources(
         species_name=pair,
         wavenumber_grid_cm1=band.grid(),
-        temperature_k=_selected_base_temperatures(args)[0],
-        pressure_pa=_selected_pressure_bars(args)[0] * 1.0e5,
+        temperature_k=_single_base_state(args)[0],
+        pressure_pa=_single_base_state(args)[1] * 1.0e5,
         line_provider=_ZeroLineProvider(),
         cia_dataset=cia_dataset,
     )
@@ -694,9 +701,10 @@ def _pair_xsection_dataset(args: argparse.Namespace) -> xr.Dataset:
         refresh=bool(args.refresh_cia),
     )
     grid = band.grid()
+    temperature_k, _ = _single_base_state(args)
     binary = np.asarray(
         cia_dataset.interpolate_to_grid(
-            temperature_k=_selected_base_temperatures(args)[0],
+            temperature_k=temperature_k,
             wavenumber_grid_cm1=grid,
         ),
         dtype=np.float64,
@@ -714,7 +722,7 @@ def _pair_xsection_dataset(args: argparse.Namespace) -> xr.Dataset:
         },
         attrs={
             "pair_name": pair,
-            "temperature_k": _selected_base_temperatures(args)[0],
+            "temperature_k": temperature_k,
             "source_filename": filename,
             **_band_attr_values(args.wn_range),
         },
@@ -722,18 +730,18 @@ def _pair_xsection_dataset(args: argparse.Namespace) -> xr.Dataset:
 
 
 def _compute_composition_products(args: argparse.Namespace):
+    temperature_k, pressure_bar = _single_base_state(args)
     mixture_args = argparse.Namespace(
         composition=args.composition,
         hitran_dir=args.hitran_dir,
-        temperature_k=_selected_base_temperatures(args)[0],
-        pressure_bar=_selected_pressure_bars(args)[0],
+        temperature_k=temperature_k,
+        pressure_bar=pressure_bar,
         resolution=args.resolution,
         cia_index_url=args.cia_index_url,
         refresh_hitran=args.refresh_hitran,
         refresh_cia=args.refresh_cia,
         broadening_composition=args.broadening_composition,
         path_length_km=getattr(args, "path_length_km", 1.0),
-        manifest=None,
     )
     return compute_mixture_overview_products(mixture_args, wn_range=args.wn_range)
 
@@ -842,13 +850,14 @@ def _compute_range_temperature_datasets(
     target_kind: str,
     worker,
 ) -> list[tuple[tuple[float, float], xr.Dataset, list[str]]]:
-    base_temperatures = _selected_base_temperatures(args)
-    pressure_bars = _selected_pressure_bars(args)
+    state_pairs = _state_pairs(args)
+    base_temperatures = [temperature_k for temperature_k, _ in state_pairs]
+    pressure_bars = [pressure_bar for _, pressure_bar in state_pairs]
     del_temperatures = _selected_del_temperatures(args)
     tasks: list[tuple[str, argparse.Namespace]] = []
     for wn_range in wn_ranges:
         range_args = _args_for_wn_range(args, wn_range)
-        for base_temperature_k, pressure_bar in zip(base_temperatures, pressure_bars, strict=True):
+        for base_temperature_k, pressure_bar in state_pairs:
             for del_temperature_k in del_temperatures:
                 tasks.append(
                     (

--- a/python/spectra/molecule_plot_cli.py
+++ b/python/spectra/molecule_plot_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterator
 from concurrent.futures import ProcessPoolExecutor
 import os
 from pathlib import Path
@@ -562,9 +563,9 @@ def _compute_overview_products(args: argparse.Namespace):
     return band, config, line_list, spectrum, transmittance, cia_dataset, line_provider
 
 
-def _print_overview_summary(*, figure_path: Path, spectrum, transmittance, cia_dataset, line_provider) -> None:
+def _print_overview_summary(*, figure_path: Path, spectrum, transmittance, cia_dataset, broadening_summary: str) -> None:
     print(f"Overview figure: {figure_path}")
-    print(f"Broadening: {line_provider.broadening_summary()}")
+    print(f"Broadening: {broadening_summary}")
     print(f"Species: {spectrum.species_name}")
     print(f"Grid points: {spectrum.wavenumber_cm1.size}")
     print(f"Path length: {transmittance.path_length_m / 1000.0:.3f} km")
@@ -633,10 +634,13 @@ def run_overview_batch(args: argparse.Namespace) -> None:
                 )
                 page_tasks.append(page_args)
                 page_metadata.append((float(temperature_k), float(pressure_bar), species, wn_min, wn_max))
-    page_results = _parallel_overview_page_products(page_tasks)
     page_count = 0
     with PdfPages(figure_path) as pdf:
-        for (temperature_k, pressure_bar, species, wn_min, wn_max), result in zip(page_metadata, page_results, strict=True):
+        for (temperature_k, pressure_bar, species, wn_min, wn_max), result in zip(
+            page_metadata,
+            _parallel_overview_page_products(page_tasks),
+            strict=True,
+        ):
             band, config, line_list, spectrum, transmittance, cia_dataset, _ = result
             fig, axes = plt.subplots(nrows=5, ncols=1, figsize=(8.5, 11.0), squeeze=False)
             _render_overview_page(
@@ -685,10 +689,15 @@ def run_overview(args: argparse.Namespace) -> None:
         page_args.temperature_k = float(temperature_k)
         page_args.pressure_bar = float(pressure_bar)
         page_tasks.append(page_args)
-    page_results = _parallel_overview_page_products(page_tasks)
 
+    final_summary: tuple[object, object, object, object, str] | None = None
     with PdfPages(figure_path) as pdf:
-        for temperature_k, pressure_bar, result in zip(_selected_temperatures(args), _selected_pressure_bars(args), page_results, strict=True):
+        for temperature_k, pressure_bar, result in zip(
+            _selected_temperatures(args),
+            _selected_pressure_bars(args),
+            _parallel_overview_page_products(page_tasks),
+            strict=True,
+        ):
             band, config, line_list, spectrum, transmittance, cia_dataset, broadening_summary = result
             fig, axes = plt.subplots(nrows=5, ncols=1, figsize=(8.5, 11.0), squeeze=False)
             _render_overview_page(
@@ -704,14 +713,17 @@ def run_overview(args: argparse.Namespace) -> None:
             pdf.savefig(fig)
             plt.close(fig)
             print(f"Added page: T={temperature_k:.1f} K | p={pressure_bar:.3f} bar")
+            final_summary = (spectrum, transmittance, cia_dataset, band, broadening_summary)
 
-    band, config, line_list, spectrum, transmittance, cia_dataset, broadening_summary = page_results[-1]
+    if final_summary is None:
+        raise ValueError("at least one overview page is required")
+    spectrum, transmittance, cia_dataset, _, broadening_summary = final_summary
     _print_overview_summary(
         figure_path=figure_path,
         spectrum=spectrum,
         transmittance=transmittance,
         cia_dataset=cia_dataset,
-        line_provider=type("_Summary", (), {"broadening_summary": lambda self: broadening_summary})(),
+        broadening_summary=broadening_summary,
     )
 
 
@@ -720,13 +732,15 @@ def _compute_overview_page_task(args: argparse.Namespace):
     return band, config, line_list, spectrum, transmittance, cia_dataset, line_provider.broadening_summary()
 
 
-def _parallel_overview_page_products(tasks: list[argparse.Namespace]):
+def _parallel_overview_page_products(tasks: list[argparse.Namespace]) -> Iterator[tuple[object, object, object, object, object, object, str]]:
     if len(tasks) <= 1:
-        return [_compute_overview_page_task(task) for task in tasks]
+        for task in tasks:
+            yield _compute_overview_page_task(task)
+        return
     max_workers = min(len(tasks), os.cpu_count() or 1)
     ctx = mp.get_context("fork")
     with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as executor:
-        return list(executor.map(_compute_overview_page_task, tasks))
+        yield from executor.map(_compute_overview_page_task, tasks)
 
 
 def _selected_temperatures(args: argparse.Namespace) -> list[float]:

--- a/python/spectra/molecule_plot_cli.py
+++ b/python/spectra/molecule_plot_cli.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ProcessPoolExecutor
 import os
 from pathlib import Path
 import tempfile
+import multiprocessing as mp
 
 os.environ.setdefault("MPLCONFIGDIR", str(Path(tempfile.gettempdir()) / "spectra_matplotlib"))
 import matplotlib
@@ -608,15 +610,16 @@ def run_overview_batch(args: argparse.Namespace) -> None:
         raise ValueError("path-length-km must be positive")
     figure_path = args.figure
     figure_path.parent.mkdir(parents=True, exist_ok=True)
-    page_count = 0
-    with PdfPages(figure_path) as pdf:
+    page_tasks: list[argparse.Namespace] = []
+    page_metadata: list[tuple[float, float, str, float, float]] = []
+    for temperature_k, pressure_bar in _state_pairs(args):
         for species in args.species:
             for wn_min, wn_max in args.wn_ranges:
                 page_args = argparse.Namespace(
                     hitran_dir=args.hitran_dir,
                     species=species,
-                    temperature_k=args.temperature_k,
-                    pressure_bar=args.pressure_bar,
+                    temperature_k=float(temperature_k),
+                    pressure_bar=float(pressure_bar),
                     wn_range=(wn_min, wn_max),
                     resolution=args.resolution,
                     refresh_hitran=args.refresh_hitran,
@@ -628,25 +631,31 @@ def run_overview_batch(args: argparse.Namespace) -> None:
                     path_length_km=args.path_length_km,
                     figure=figure_path,
                 )
-                band, config, line_list, spectrum, transmittance, cia_dataset, line_provider = _compute_overview_products(page_args)
-                fig, axes = plt.subplots(nrows=5, ncols=1, figsize=(8.5, 11.0), squeeze=False)
-                _render_overview_page(
-                    fig,
-                    axes[:, 0],
-                    band=band,
-                    config=config,
-                    spectrum=spectrum,
-                    transmittance=transmittance,
-                    line_list=line_list,
-                    cia_dataset=cia_dataset,
-                )
-                pdf.savefig(fig)
-                plt.close(fig)
-                page_count += 1
-                component_label = _resolve_overview_component_label(cia_dataset=cia_dataset, spectrum=spectrum) if np.any(np.asarray(spectrum.sigma_cia_cm2_molecule, dtype=np.float64) > 0.0) else "none"
-                print(
-                    f"Added page {page_count}: {species} | {wn_min:.3f}-{wn_max:.3f} cm^-1 | secondary={component_label}"
-                )
+                page_tasks.append(page_args)
+                page_metadata.append((float(temperature_k), float(pressure_bar), species, wn_min, wn_max))
+    page_results = _parallel_overview_page_products(page_tasks)
+    page_count = 0
+    with PdfPages(figure_path) as pdf:
+        for (temperature_k, pressure_bar, species, wn_min, wn_max), result in zip(page_metadata, page_results, strict=True):
+            band, config, line_list, spectrum, transmittance, cia_dataset, _ = result
+            fig, axes = plt.subplots(nrows=5, ncols=1, figsize=(8.5, 11.0), squeeze=False)
+            _render_overview_page(
+                fig,
+                axes[:, 0],
+                band=band,
+                config=config,
+                spectrum=spectrum,
+                transmittance=transmittance,
+                line_list=line_list,
+                cia_dataset=cia_dataset,
+            )
+            pdf.savefig(fig)
+            plt.close(fig)
+            page_count += 1
+            component_label = _resolve_overview_component_label(cia_dataset=cia_dataset, spectrum=spectrum) if np.any(np.asarray(spectrum.sigma_cia_cm2_molecule, dtype=np.float64) > 0.0) else "none"
+            print(
+                f"Added page {page_count}: T={temperature_k:.1f} K | p={pressure_bar:.3f} bar | {species} | {wn_min:.3f}-{wn_max:.3f} cm^-1 | secondary={component_label}"
+            )
     print(f"Combined overview figure: {figure_path}")
     print(f"Pages: {page_count}")
 
@@ -668,28 +677,75 @@ def main_overview() -> None:
 
 
 def run_overview(args: argparse.Namespace) -> None:
-    band, config, line_list, spectrum, transmittance, cia_dataset, line_provider = _compute_overview_products(args)
     figure_path = args.figure
     figure_path.parent.mkdir(parents=True, exist_ok=True)
+    page_tasks: list[argparse.Namespace] = []
+    for temperature_k, pressure_bar in _state_pairs(args):
+        page_args = argparse.Namespace(**vars(args))
+        page_args.temperature_k = float(temperature_k)
+        page_args.pressure_bar = float(pressure_bar)
+        page_tasks.append(page_args)
+    page_results = _parallel_overview_page_products(page_tasks)
 
-    fig, axes = plt.subplots(nrows=5, ncols=1, figsize=(8.5, 11.0), squeeze=False)
-    _render_overview_page(
-        fig,
-        axes[:, 0],
-        band=band,
-        config=config,
-        spectrum=spectrum,
-        transmittance=transmittance,
-        line_list=line_list,
-        cia_dataset=cia_dataset,
-    )
-    fig.savefig(figure_path)
-    plt.close(fig)
+    with PdfPages(figure_path) as pdf:
+        for temperature_k, pressure_bar, result in zip(_selected_temperatures(args), _selected_pressure_bars(args), page_results, strict=True):
+            band, config, line_list, spectrum, transmittance, cia_dataset, broadening_summary = result
+            fig, axes = plt.subplots(nrows=5, ncols=1, figsize=(8.5, 11.0), squeeze=False)
+            _render_overview_page(
+                fig,
+                axes[:, 0],
+                band=band,
+                config=config,
+                spectrum=spectrum,
+                transmittance=transmittance,
+                line_list=line_list,
+                cia_dataset=cia_dataset,
+            )
+            pdf.savefig(fig)
+            plt.close(fig)
+            print(f"Added page: T={temperature_k:.1f} K | p={pressure_bar:.3f} bar")
 
+    band, config, line_list, spectrum, transmittance, cia_dataset, broadening_summary = page_results[-1]
     _print_overview_summary(
         figure_path=figure_path,
         spectrum=spectrum,
         transmittance=transmittance,
         cia_dataset=cia_dataset,
-        line_provider=line_provider,
+        line_provider=type("_Summary", (), {"broadening_summary": lambda self: broadening_summary})(),
     )
+
+
+def _compute_overview_page_task(args: argparse.Namespace):
+    band, config, line_list, spectrum, transmittance, cia_dataset, line_provider = _compute_overview_products(args)
+    return band, config, line_list, spectrum, transmittance, cia_dataset, line_provider.broadening_summary()
+
+
+def _parallel_overview_page_products(tasks: list[argparse.Namespace]):
+    if len(tasks) <= 1:
+        return [_compute_overview_page_task(task) for task in tasks]
+    max_workers = min(len(tasks), os.cpu_count() or 1)
+    ctx = mp.get_context("fork")
+    with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as executor:
+        return list(executor.map(_compute_overview_page_task, tasks))
+
+
+def _selected_temperatures(args: argparse.Namespace) -> list[float]:
+    values = getattr(args, "temperature_k", [300.0])
+    if isinstance(values, (list, tuple)):
+        return [float(value) for value in values]
+    return [float(values)]
+
+
+def _selected_pressure_bars(args: argparse.Namespace) -> list[float]:
+    values = getattr(args, "pressure_bar", [1.0])
+    if isinstance(values, (list, tuple)):
+        return [float(value) for value in values]
+    return [float(values)]
+
+
+def _state_pairs(args: argparse.Namespace) -> list[tuple[float, float]]:
+    temperatures = _selected_temperatures(args)
+    pressures = _selected_pressure_bars(args)
+    if len(temperatures) != len(pressures):
+        raise ValueError("temperature_k and pressure_bar must have the same number of values")
+    return list(zip(temperatures, pressures, strict=True))

--- a/python/spectra/output_names.py
+++ b/python/spectra/output_names.py
@@ -46,8 +46,8 @@ def default_output_path(
         [
             _clean_token(target_name),
             _clean_token(plot_type),
-            _format_value(pressure_bar, "bar"),
             _format_value(temperature_k, "K"),
+            _format_value(pressure_bar, "bar"),
             _format_value(wn_min),
             _format_value(wn_max, "cm1"),
         ]

--- a/python/spectra/plot_cli.py
+++ b/python/spectra/plot_cli.py
@@ -164,19 +164,6 @@ def _stateful_output_path(
     return output_path.with_name(f"{output_path.stem}{_state_output_suffix(temperature_k, pressure_bar)}{suffix}")
 
 
-def _stateful_manifest_path(
-    manifest_path: Path | None,
-    *,
-    num_states: int,
-    temperature_k: float,
-    pressure_bar: float,
-) -> Path | None:
-    if manifest_path is None or num_states <= 1:
-        return manifest_path
-    suffix = manifest_path.suffix or ".json"
-    return manifest_path.with_name(f"{manifest_path.stem}{_state_output_suffix(temperature_k, pressure_bar)}{suffix}")
-
-
 def _args_for_state(args: argparse.Namespace, *, temperature_k: float, pressure_bar: float) -> argparse.Namespace:
     scoped = argparse.Namespace(**vars(args))
     scoped.temperature_k = float(temperature_k)

--- a/python/spectra/plot_cli.py
+++ b/python/spectra/plot_cli.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ProcessPoolExecutor
+import multiprocessing as mp
+import os
 from pathlib import Path
 from textwrap import dedent
 
 from . import atm_overview_cli, cia_plot_cli, molecule_plot_cli
-from .output_names import default_output_path
+from .output_names import _format_value, default_output_path
 
 
 class _SplitSpeciesAction(argparse.Action):
@@ -32,9 +35,19 @@ class _HelpFormatter(argparse.RawDescriptionHelpFormatter):
         return help_text
 
 
+def _parse_float_list(value: str) -> list[float]:
+    parts = [part.strip() for part in str(value).split(",")]
+    if not parts or any(part == "" for part in parts):
+        raise argparse.ArgumentTypeError("value must be a number or comma-separated list of numbers")
+    try:
+        return [float(part) for part in parts]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("value must contain numeric values") from exc
+
+
 def _add_state_arguments(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--temperature-k", type=float, default=300.0, metavar="K", help="Gas temperature in kelvin.")
-    parser.add_argument("--pressure-bar", type=float, default=1.0, metavar="BAR", help="Gas pressure in bar.")
+    parser.add_argument("--temperature-k", type=_parse_float_list, default=[300.0], metavar="K[,K...]", help="Gas temperature in kelvin. Use a comma-separated list paired one-to-one with --pressure-bar.")
+    parser.add_argument("--pressure-bar", type=_parse_float_list, default=[1.0], metavar="BAR[,BAR...]", help="Gas pressure in bar. Use a comma-separated list paired one-to-one with --temperature-k.")
 
 
 def _add_common_arguments(parser: argparse.ArgumentParser, *, allow_multiple_ranges: bool = False) -> None:
@@ -85,6 +98,27 @@ def _validate_single_selector(args: argparse.Namespace, parser: argparse.Argumen
         parser.error("choose only one of --pair, --species, or --composition")
 
 
+def _selected_temperatures(args: argparse.Namespace) -> list[float]:
+    values = getattr(args, "temperature_k", [300.0])
+    if isinstance(values, (list, tuple)):
+        return [float(value) for value in values]
+    return [float(values)]
+
+
+def _selected_pressure_bars(args: argparse.Namespace) -> list[float]:
+    values = getattr(args, "pressure_bar", [1.0])
+    if isinstance(values, (list, tuple)):
+        return [float(value) for value in values]
+    return [float(values)]
+
+
+def _validate_state_grid(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    temperatures = _selected_temperatures(args)
+    pressures = _selected_pressure_bars(args)
+    if len(temperatures) != len(pressures):
+        parser.error("--temperature-k and --pressure-bar must have the same number of values")
+
+
 def _combined_range(wn_ranges: list[tuple[float, float]]) -> tuple[float, float]:
     return min(wn_min for wn_min, _ in wn_ranges), max(wn_max for _, wn_max in wn_ranges)
 
@@ -107,6 +141,55 @@ def _default_figure(
         wn_range=wn_range,
         suffix=suffix,
         output_dir=output_dir,
+    )
+
+
+def _state_output_suffix(temperature_k: float, pressure_bar: float) -> str:
+    return f"_{_format_value(temperature_k, 'K')}_{_format_value(pressure_bar, 'bar')}"
+
+
+def _stateful_output_path(
+    output_path: Path | None,
+    *,
+    num_states: int,
+    temperature_k: float,
+    pressure_bar: float,
+    default_path: Path,
+) -> Path:
+    if output_path is None:
+        return default_path
+    if num_states <= 1:
+        return output_path
+    suffix = output_path.suffix or default_path.suffix
+    return output_path.with_name(f"{output_path.stem}{_state_output_suffix(temperature_k, pressure_bar)}{suffix}")
+
+
+def _stateful_manifest_path(
+    manifest_path: Path | None,
+    *,
+    num_states: int,
+    temperature_k: float,
+    pressure_bar: float,
+) -> Path | None:
+    if manifest_path is None or num_states <= 1:
+        return manifest_path
+    suffix = manifest_path.suffix or ".json"
+    return manifest_path.with_name(f"{manifest_path.stem}{_state_output_suffix(temperature_k, pressure_bar)}{suffix}")
+
+
+def _args_for_state(args: argparse.Namespace, *, temperature_k: float, pressure_bar: float) -> argparse.Namespace:
+    scoped = argparse.Namespace(**vars(args))
+    scoped.temperature_k = float(temperature_k)
+    scoped.pressure_bar = float(pressure_bar)
+    return scoped
+
+
+def _overview_state_token(*, temperatures: list[float], pressures: list[float]) -> tuple[float | str, float | str]:
+    if len(temperatures) == 1 and len(pressures) == 1:
+        return temperatures[0], pressures[0]
+    return (
+        f"{_format_value(min(temperatures))}_{_format_value(max(temperatures), 'K')}",
+        f"{_format_value(min(pressures))}_{_format_value(max(pressures), 'bar')}",
     )
 
 
@@ -257,6 +340,7 @@ def _as_atm_args(args: argparse.Namespace, *, plot_type: str, wn_range: tuple[fl
         pressure_bar=args.pressure_bar,
         path_length_km=getattr(args, "path_length_km", 1.0),
         resolution=args.resolution,
+        wn_range=wn_range,
         cia_index_url=args.cia_index_url,
         refresh_hitran=args.refresh_hitran,
         refresh_cia=args.refresh_cia,
@@ -271,6 +355,54 @@ def _as_atm_args(args: argparse.Namespace, *, plot_type: str, wn_range: tuple[fl
             output_dir=args.output_dir,
         ),
     )
+
+
+def _parallel_plot_results(
+    tasks: list[tuple[str, argparse.Namespace]],
+    *,
+    worker,
+) -> list[None]:
+    if len(tasks) <= 1:
+        return [worker(task) for task in tasks]
+    max_workers = min(len(tasks), os.cpu_count() or 1)
+    ctx = mp.get_context("fork")
+    with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as executor:
+        return list(executor.map(worker, tasks))
+
+
+def _run_plot_task(task: tuple[str, argparse.Namespace]) -> None:
+    task_kind, task_args = task
+    if task_kind == "molecule_xsection":
+        molecule_plot_cli.run_xsection(task_args)
+        return
+    if task_kind == "molecule_attenuation":
+        molecule_plot_cli.run_attenuation(task_args)
+        return
+    if task_kind == "molecule_transmission":
+        molecule_plot_cli.run_transmission(task_args)
+        return
+    if task_kind == "molecule_overview":
+        molecule_plot_cli.run_overview(task_args)
+        return
+    if task_kind == "molecule_overview_batch":
+        molecule_plot_cli.run_overview_batch(task_args)
+        return
+    if task_kind == "cia_attenuation":
+        cia_plot_cli.run_attenuation(task_args)
+        return
+    if task_kind == "cia_transmission":
+        cia_plot_cli.run_transmission(task_args)
+        return
+    if task_kind == "atm_attenuation":
+        atm_overview_cli.run_atm_attenuation(task_args, wn_range=task_args.wn_range)
+        return
+    if task_kind == "atm_transmission":
+        atm_overview_cli.run_atm_transmission(task_args, wn_range=task_args.wn_range)
+        return
+    if task_kind == "atm_overview":
+        atm_overview_cli.run_atm_overview(task_args)
+        return
+    raise ValueError(f"unsupported plot task: {task_kind}")
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -408,44 +540,141 @@ def main(argv: list[str] | None = None) -> None:
         cia_plot_cli.run_binary(_as_cia_args(args, default_pair="H2-H2", plot_type="binary"))
         return
 
+    _validate_state_grid(args, parser)
+    state_pairs = list(zip(_selected_temperatures(args), _selected_pressure_bars(args), strict=True))
+
     if args.command == "xsection":
-        molecule_plot_cli.run_xsection(_as_molecule_args(args, plot_type="xsection"))
+        tasks = []
+        wn_range = args.wn_range or (20.0, 2500.0)
+        for temperature_k, pressure_bar in state_pairs:
+            state_args = _args_for_state(args, temperature_k=temperature_k, pressure_bar=pressure_bar)
+            default_path = _default_figure(
+                target_name=state_args.species or "H2O",
+                plot_type="xsection",
+                temperature_k=temperature_k,
+                pressure_bar=pressure_bar,
+                wn_range=wn_range,
+                output_dir=state_args.output_dir,
+            )
+            state_args.figure = _stateful_output_path(
+                state_args.figure,
+                num_states=len(state_pairs),
+                temperature_k=temperature_k,
+                pressure_bar=pressure_bar,
+                default_path=default_path,
+            )
+            tasks.append(("molecule_xsection", _as_molecule_args(state_args, plot_type="xsection")))
+        _parallel_plot_results(tasks, worker=_run_plot_task)
         return
 
     if args.command in {"attenuation", "transmission"}:
         _validate_single_selector(args, parser)
         if args.composition:
+            tasks = []
             wn_range = args.wn_range or (20.0, 2500.0)
-            atm_args = _as_atm_args(args, plot_type=args.command, wn_range=wn_range)
-            if args.command == "attenuation":
-                atm_overview_cli.run_atm_attenuation(atm_args, wn_range=wn_range)
-            else:
-                atm_overview_cli.run_atm_transmission(atm_args, wn_range=wn_range)
+            for temperature_k, pressure_bar in state_pairs:
+                state_args = _args_for_state(args, temperature_k=temperature_k, pressure_bar=pressure_bar)
+                default_path = _default_figure(
+                    target_name=state_args.composition,
+                    plot_type=args.command,
+                    temperature_k=temperature_k,
+                    pressure_bar=pressure_bar,
+                    wn_range=wn_range,
+                    output_dir=state_args.output_dir,
+                )
+                state_args.figure = _stateful_output_path(
+                    state_args.figure,
+                    num_states=len(state_pairs),
+                    temperature_k=temperature_k,
+                    pressure_bar=pressure_bar,
+                    default_path=default_path,
+                )
+                tasks.append((f"atm_{args.command}", _as_atm_args(state_args, plot_type=args.command, wn_range=wn_range)))
+            _parallel_plot_results(tasks, worker=_run_plot_task)
             return
         if args.pair:
-            cia_args = _as_cia_args(args, default_pair=args.pair, plot_type=args.command)
-            if args.command == "attenuation":
-                cia_plot_cli.run_attenuation(cia_args)
-            else:
-                cia_plot_cli.run_transmission(cia_args)
+            tasks = []
+            wn_range = args.wn_range or (20.0, 10000.0)
+            for temperature_k, pressure_bar in state_pairs:
+                state_args = _args_for_state(args, temperature_k=temperature_k, pressure_bar=pressure_bar)
+                default_path = _default_figure(
+                    target_name=state_args.pair,
+                    plot_type=args.command,
+                    temperature_k=temperature_k,
+                    pressure_bar=pressure_bar,
+                    wn_range=wn_range,
+                    output_dir=state_args.output_dir,
+                )
+                state_args.figure = _stateful_output_path(
+                    state_args.figure,
+                    num_states=len(state_pairs),
+                    temperature_k=temperature_k,
+                    pressure_bar=pressure_bar,
+                    default_path=default_path,
+                )
+                task_kind = "cia_attenuation" if args.command == "attenuation" else "cia_transmission"
+                tasks.append((task_kind, _as_cia_args(state_args, default_pair=state_args.pair, plot_type=args.command)))
+            _parallel_plot_results(tasks, worker=_run_plot_task)
             return
 
-        molecule_args = _as_molecule_args(args, plot_type=args.command)
-        if args.command == "attenuation":
-            molecule_plot_cli.run_attenuation(molecule_args)
-        else:
-            molecule_plot_cli.run_transmission(molecule_args)
+        tasks = []
+        wn_range = args.wn_range or (20.0, 2500.0)
+        for temperature_k, pressure_bar in state_pairs:
+            state_args = _args_for_state(args, temperature_k=temperature_k, pressure_bar=pressure_bar)
+            default_path = _default_figure(
+                target_name=state_args.species or "H2O",
+                plot_type=args.command,
+                temperature_k=temperature_k,
+                pressure_bar=pressure_bar,
+                wn_range=wn_range,
+                output_dir=state_args.output_dir,
+            )
+            state_args.figure = _stateful_output_path(
+                state_args.figure,
+                num_states=len(state_pairs),
+                temperature_k=temperature_k,
+                pressure_bar=pressure_bar,
+                default_path=default_path,
+            )
+            task_kind = "molecule_attenuation" if args.command == "attenuation" else "molecule_transmission"
+            tasks.append((task_kind, _as_molecule_args(state_args, plot_type=args.command)))
+        _parallel_plot_results(tasks, worker=_run_plot_task)
         return
 
     if args.command == "overview":
         if args.composition and args.species:
             parser.error("choose only one of --composition or --species")
         wn_ranges = args.wn_ranges or [(20.0, 2500.0)]
+        temperatures = _selected_temperatures(args)
+        pressures = _selected_pressure_bars(args)
+        temperature_token, pressure_token = _overview_state_token(temperatures=temperatures, pressures=pressures)
         if args.composition:
+            combined_range = _combined_range(wn_ranges)
+            default_path = _default_figure(
+                target_name=args.composition,
+                plot_type="overview",
+                temperature_k=temperature_token,
+                pressure_bar=pressure_token,
+                wn_range=combined_range,
+                output_dir=args.output_dir,
+                suffix=".pdf",
+            )
+            args.figure = args.figure or default_path
             atm_overview_cli.run_atm_overview(_as_atm_overview_args(args, wn_ranges=wn_ranges))
             return
 
         species = args.species or ["H2O"]
+        combined_range = _combined_range(wn_ranges)
+        default_path = _default_figure(
+            target_name=species[0] if len(species) == 1 else "_".join(species),
+            plot_type="overview",
+            temperature_k=temperature_token,
+            pressure_bar=pressure_token,
+            wn_range=combined_range,
+            output_dir=args.output_dir,
+            suffix=".pdf",
+        )
+        args.figure = args.figure or default_path
         if len(species) == 1 and len(wn_ranges) == 1:
             molecule_plot_cli.run_overview(_as_molecule_overview_args(args, species=species[0], wn_range=wn_ranges[0]))
         else:

--- a/python/spectra/plot_cli.py
+++ b/python/spectra/plot_cli.py
@@ -188,8 +188,8 @@ def _overview_state_token(*, temperatures: list[float], pressures: list[float]) 
     if len(temperatures) == 1 and len(pressures) == 1:
         return temperatures[0], pressures[0]
     return (
-        f"{_format_value(min(temperatures))}_{_format_value(max(temperatures), 'K')}",
-        f"{_format_value(min(pressures))}_{_format_value(max(pressures), 'bar')}",
+        f"{_format_value(min(temperatures))}_{_format_value(max(temperatures))}",
+        f"{_format_value(min(pressures))}_{_format_value(max(pressures))}",
     )
 
 

--- a/tests/spectra/test_atm_overview_cli.py
+++ b/tests/spectra/test_atm_overview_cli.py
@@ -1,6 +1,8 @@
+import json
+
 import numpy as np
 
-from pyharp.spectra.atm_overview_cli import _find_binary_pairs, _parse_composition, compute_mixture_overview_products, build_atm_overview_parser
+from pyharp.spectra.atm_overview_cli import _find_binary_pairs, _parse_composition, compute_mixture_overview_products, build_atm_overview_parser, run_atm_overview
 
 
 def test_parse_composition_normalizes_and_merges_duplicates() -> None:
@@ -101,3 +103,78 @@ def test_compute_mixture_overview_reports_broadening_fallback(monkeypatch, tmp_p
 
     out = capsys.readouterr().out
     assert "CO2 broadening: requested=h2:0.900,he:0.100 -> effective=air:1.000" in out
+
+
+def test_run_atm_overview_manifest_always_uses_state_lists(monkeypatch, tmp_path) -> None:
+    parser = build_atm_overview_parser()
+    args = parser.parse_args(
+        [
+            "--composition",
+            "H2:0.9,He:0.1",
+            "--temperature-k",
+            "300",
+            "--pressure-bar",
+            "1",
+            "--wn-range=20,2500",
+            "--figure",
+            str(tmp_path / "overview.pdf"),
+            "--manifest",
+            str(tmp_path / "overview.manifest.json"),
+        ]
+    )
+    written = {}
+
+    class _DummyPdf:
+        def __init__(self, path):
+            self.path = path
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def savefig(self, fig):
+            return None
+
+    products = type(
+        "Products",
+        (),
+        {
+            "band": type(
+                "Band",
+                (),
+                {"wavenumber_min_cm1": 20.0, "wavenumber_max_cm1": 2500.0, "resolution_cm1": 1.0},
+            )(),
+            "spectrum": type(
+                "Spectrum",
+                (),
+                {"wavenumber_cm1": np.array([20.0, 21.0]), "temperature_k": 300.0, "pressure_pa": 1.0e5},
+            )(),
+            "species_terms": (),
+            "manifest_sources": (),
+            "transmittance": object(),
+        },
+    )()
+
+    monkeypatch.setattr(
+        "pyharp.spectra.atm_overview_cli._parallel_mixture_overview_products",
+        lambda tasks: iter([products]),
+    )
+    monkeypatch.setattr("pyharp.spectra.atm_overview_cli._render_mixture_overview", lambda fig, axes, *, products: None)
+    monkeypatch.setattr("pyharp.spectra.atm_overview_cli.PdfPages", _DummyPdf)
+    monkeypatch.setattr(
+        "pyharp.spectra.atm_overview_cli.plt.subplots",
+        lambda **kwargs: (object(), np.array([[object()], [object()], [object()], [object()]])),
+    )
+    monkeypatch.setattr("pyharp.spectra.atm_overview_cli.plt.close", lambda fig: None)
+    monkeypatch.setattr(
+        "pathlib.Path.write_text",
+        lambda self, text: written.setdefault(str(self), text),
+    )
+
+    run_atm_overview(args)
+
+    manifest = json.loads(written[str(tmp_path / "overview.manifest.json")])
+    assert manifest["temperature_k"] == [300.0]
+    assert manifest["pressure_bar"] == [1.0]

--- a/tests/spectra/test_cli.py
+++ b/tests/spectra/test_cli.py
@@ -14,7 +14,7 @@ from pyharp.spectra.spectrum import AbsorptionSpectrum
 def test_default_paths_are_inside_project_root() -> None:
     root = project_root()
     assert default_output_path().is_relative_to(root)
-    assert default_output_path().name == "co2_xsection_1bar_300K_20_2500cm1.nc"
+    assert default_output_path().name == "co2_xsection_300K_1bar_20_2500cm1.nc"
     assert default_output_path().parent.name == "output"
     assert default_hitran_dir() == default_hitran_dir().parent / "hitran"
     assert default_hitran_dir().is_absolute() is False

--- a/tests/spectra/test_output_names.py
+++ b/tests/spectra/test_output_names.py
@@ -13,7 +13,7 @@ def test_default_output_path_uses_requested_pattern() -> None:
         suffix=".png",
     )
 
-    assert path == Path("output/co2_xsection_1bar_300K_20_2500cm1.png")
+    assert path == Path("output/co2_xsection_300K_1bar_20_2500cm1.png")
 
 
 def test_default_output_path_sanitizes_cia_and_composition_names() -> None:
@@ -34,5 +34,5 @@ def test_default_output_path_sanitizes_cia_and_composition_names() -> None:
         suffix=".pdf",
     )
 
-    assert cia_path == Path("output/h2_he_attenuation_0p25bar_275p5K_25_30p5cm1.png")
-    assert composition_path == Path("output/h2o_0p1_h2_0p9_overview_1bar_300K_25_2500cm1.pdf")
+    assert cia_path == Path("output/h2_he_attenuation_275p5K_0p25bar_25_30p5cm1.png")
+    assert composition_path == Path("output/h2o_0p1_h2_0p9_overview_300K_1bar_25_2500cm1.pdf")

--- a/tests/spectra/test_plot_cli.py
+++ b/tests/spectra/test_plot_cli.py
@@ -52,9 +52,29 @@ def test_plot_parser_accepts_molecule_xsection_with_wn_range(tmp_path) -> None:
 
     assert args.command == "xsection"
     assert args.species == "CO2"
+    assert args.temperature_k == [300.0]
+    assert args.pressure_bar == [1.0]
     assert args.broadening_composition == "air:0.8,self:0.2"
     assert args.wn_range == (20.0, 2500.0)
     assert args.figure == tmp_path / "co2.png"
+
+
+def test_plot_parser_accepts_matched_temperature_pressure_vectors() -> None:
+    parser = plot_cli.build_parser()
+    args = parser.parse_args(
+        [
+            "transmission",
+            "--species",
+            "CO2",
+            "--temperature-k",
+            "300,400",
+            "--pressure-bar",
+            "1,10",
+        ]
+    )
+
+    assert args.temperature_k == [300.0, 400.0]
+    assert args.pressure_bar == [1.0, 10.0]
 
 
 def test_plot_parser_accepts_atm_overview_ranges(tmp_path) -> None:
@@ -111,6 +131,72 @@ def test_plot_main_dispatches_molecule_xsection_with_default_figure(monkeypatch)
 
     assert len(calls) == 1
     assert calls[0].figure.name == "co2_xsection_0p25bar_275p5K_25_30p5cm1.png"
+
+
+def test_plot_main_dispatches_one_xsection_per_state_pair(monkeypatch, tmp_path) -> None:
+    calls = []
+
+    def fake_run(args):
+        calls.append(args)
+
+    monkeypatch.setattr("pyharp.spectra.plot_cli.molecule_plot_cli.run_xsection", fake_run)
+    monkeypatch.setattr(
+        "pyharp.spectra.plot_cli._parallel_plot_results",
+        lambda tasks, *, worker: [worker(task) for task in tasks],
+    )
+
+    plot_cli.main(
+        [
+            "xsection",
+            "--species",
+            "CO2",
+            "--temperature-k",
+            "275.5,300",
+            "--pressure-bar",
+            "0.25,1",
+            "--wn-range",
+            "25,30.5",
+            "--output-dir",
+            str(tmp_path / "figures"),
+        ]
+    )
+
+    assert [(call.temperature_k, call.pressure_bar, call.figure.name) for call in calls] == [
+        (275.5, 0.25, "co2_xsection_0p25bar_275p5K_25_30p5cm1.png"),
+        (300.0, 1.0, "co2_xsection_1bar_300K_25_30p5cm1.png"),
+    ]
+
+
+def test_plot_main_appends_state_suffix_to_explicit_output_for_multiple_pairs(monkeypatch, tmp_path) -> None:
+    calls = []
+
+    def fake_run(args):
+        calls.append(args)
+
+    monkeypatch.setattr("pyharp.spectra.plot_cli.molecule_plot_cli.run_xsection", fake_run)
+    monkeypatch.setattr(
+        "pyharp.spectra.plot_cli._parallel_plot_results",
+        lambda tasks, *, worker: [worker(task) for task in tasks],
+    )
+
+    plot_cli.main(
+        [
+            "xsection",
+            "--species",
+            "CO2",
+            "--temperature-k",
+            "300,400",
+            "--pressure-bar",
+            "1,10",
+            "--output",
+            str(tmp_path / "co2.png"),
+        ]
+    )
+
+    assert [call.figure for call in calls] == [
+        tmp_path / "co2_300K_1bar.png",
+        tmp_path / "co2_400K_10bar.png",
+    ]
 
 
 def test_plot_main_uses_output_dir_for_default_figure(monkeypatch, tmp_path) -> None:
@@ -294,6 +380,94 @@ def test_plot_composition_transmission_matches_dump_total(monkeypatch, tmp_path)
 def test_plot_main_rejects_multiple_selectors() -> None:
     with pytest.raises(SystemExit):
         plot_cli.main(["attenuation", "--pair", "H2-H2", "--species", "H2O"])
+
+
+def test_plot_main_rejects_mismatched_temperature_pressure_vectors() -> None:
+    with pytest.raises(SystemExit):
+        plot_cli.main(["xsection", "--species", "CO2", "--temperature-k", "300,400", "--pressure-bar", "1"])
+
+
+def test_plot_overview_parallelizes_over_state_pairs_and_wn_ranges(monkeypatch, tmp_path) -> None:
+    inner_task_counts = []
+    calls = []
+
+    def fake_parallel_products(tasks):
+        inner_task_counts.append(len(tasks))
+        calls.append(tasks)
+        return [
+            type("Products", (), {"spectrum": type("Spectrum", (), {"temperature_k": 300.0, "pressure_pa": 1.0e5})()})()
+            for _ in tasks
+        ]
+
+    class _DummyPdf:
+        def __init__(self, path):
+            self.path = path
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def savefig(self, fig):
+            return None
+
+    dummy_figure = type("Figure", (), {})()
+    dummy_axis = type("Axis", (), {})()
+
+    monkeypatch.setattr("pyharp.spectra.atm_overview_cli._parallel_mixture_overview_products", fake_parallel_products)
+    monkeypatch.setattr("pyharp.spectra.atm_overview_cli._render_mixture_overview", lambda fig, axes, *, products: None)
+    monkeypatch.setattr("pyharp.spectra.atm_overview_cli._page_manifest", lambda products: {})
+    monkeypatch.setattr("pyharp.spectra.atm_overview_cli.PdfPages", _DummyPdf)
+    monkeypatch.setattr("pyharp.spectra.atm_overview_cli.plt.subplots", lambda **kwargs: (dummy_figure, np.array([[dummy_axis], [dummy_axis], [dummy_axis], [dummy_axis]])))
+    monkeypatch.setattr("pyharp.spectra.atm_overview_cli.plt.close", lambda fig: None)
+
+    plot_cli.main(
+        [
+            "overview",
+            "--composition",
+            "H2:0.9,He:0.1",
+            "--temperature-k",
+            "300,400,500",
+            "--pressure-bar",
+            "1,2,3",
+            "--wn-range=20,2500",
+            "--wn-range=2500,10000",
+            "--output",
+            str(tmp_path / "atm.pdf"),
+        ]
+    )
+
+    assert inner_task_counts == [6]
+    assert all(task_args.figure == tmp_path / "atm.pdf" for task_args, _ in calls[0])
+
+
+def test_plot_overview_uses_single_output_pdf_for_multiple_state_pairs(monkeypatch, tmp_path) -> None:
+    calls = []
+
+    def fake_run(args):
+        calls.append(args)
+
+    monkeypatch.setattr("pyharp.spectra.plot_cli.molecule_plot_cli.run_overview", fake_run)
+
+    plot_cli.main(
+        [
+            "overview",
+            "--species",
+            "CO2",
+            "--temperature-k",
+            "300,400",
+            "--pressure-bar",
+            "1,10",
+            "--output",
+            str(tmp_path / "overview.pdf"),
+        ]
+    )
+
+    assert len(calls) == 1
+    assert calls[0].figure == tmp_path / "overview.pdf"
+    assert calls[0].temperature_k == [300.0, 400.0]
+    assert calls[0].pressure_bar == [1.0, 10.0]
 
 
 def test_plot_help_includes_subcommands_and_examples(capsys) -> None:

--- a/tests/spectra/test_plot_cli.py
+++ b/tests/spectra/test_plot_cli.py
@@ -470,6 +470,35 @@ def test_plot_overview_uses_single_output_pdf_for_multiple_state_pairs(monkeypat
     assert calls[0].pressure_bar == [1.0, 10.0]
 
 
+def test_plot_overview_uses_combined_default_name_without_duplicate_units(monkeypatch, tmp_path) -> None:
+    calls = []
+
+    def fake_run(args):
+        calls.append(args)
+
+    monkeypatch.setattr("pyharp.spectra.plot_cli.molecule_plot_cli.run_overview_batch", fake_run)
+
+    plot_cli.main(
+        [
+            "overview",
+            "--species",
+            "CO2",
+            "H2O",
+            "--temperature-k",
+            "170,400,780",
+            "--pressure-bar",
+            "0.1,1,100",
+            "--wn-range=20,2500",
+            "--wn-range=2500,10000",
+            "--output-dir",
+            str(tmp_path / "figures"),
+        ]
+    )
+
+    assert len(calls) == 1
+    assert calls[0].figure == tmp_path / "figures" / "co2_h2o_overview_0p1_100bar_170_780K_20_10000cm1.pdf"
+
+
 def test_plot_help_includes_subcommands_and_examples(capsys) -> None:
     with pytest.raises(SystemExit) as excinfo:
         plot_cli.main(["-h"])

--- a/tests/spectra/test_plot_cli.py
+++ b/tests/spectra/test_plot_cli.py
@@ -116,7 +116,7 @@ def test_plot_main_dispatches_pair_attenuation(monkeypatch) -> None:
     assert len(calls) == 1
     assert calls[0].pair == "H2-He"
     assert calls[0].wn_range == (25.0, 30.0)
-    assert calls[0].figure.name == "h2_he_attenuation_1bar_300K_25_30cm1.png"
+    assert calls[0].figure.name == "h2_he_attenuation_300K_1bar_25_30cm1.png"
 
 
 def test_plot_main_dispatches_molecule_xsection_with_default_figure(monkeypatch) -> None:
@@ -130,7 +130,7 @@ def test_plot_main_dispatches_molecule_xsection_with_default_figure(monkeypatch)
     plot_cli.main(["xsection", "--species", "CO2", "--temperature-k", "275.5", "--pressure-bar", "0.25", "--wn-range", "25,30.5"])
 
     assert len(calls) == 1
-    assert calls[0].figure.name == "co2_xsection_0p25bar_275p5K_25_30p5cm1.png"
+    assert calls[0].figure.name == "co2_xsection_275p5K_0p25bar_25_30p5cm1.png"
 
 
 def test_plot_main_dispatches_one_xsection_per_state_pair(monkeypatch, tmp_path) -> None:
@@ -162,8 +162,8 @@ def test_plot_main_dispatches_one_xsection_per_state_pair(monkeypatch, tmp_path)
     )
 
     assert [(call.temperature_k, call.pressure_bar, call.figure.name) for call in calls] == [
-        (275.5, 0.25, "co2_xsection_0p25bar_275p5K_25_30p5cm1.png"),
-        (300.0, 1.0, "co2_xsection_1bar_300K_25_30p5cm1.png"),
+        (275.5, 0.25, "co2_xsection_275p5K_0p25bar_25_30p5cm1.png"),
+        (300.0, 1.0, "co2_xsection_300K_1bar_25_30p5cm1.png"),
     ]
 
 
@@ -224,7 +224,7 @@ def test_plot_main_uses_output_dir_for_default_figure(monkeypatch, tmp_path) -> 
     )
 
     assert len(calls) == 1
-    assert calls[0].figure == tmp_path / "figures" / "co2_xsection_0p25bar_275p5K_25_30p5cm1.png"
+    assert calls[0].figure == tmp_path / "figures" / "co2_xsection_275p5K_0p25bar_25_30p5cm1.png"
 
 
 def test_plot_main_passes_broadening_composition_to_molecule_workflow(monkeypatch) -> None:
@@ -252,7 +252,7 @@ def test_plot_main_dispatches_composition_attenuation(monkeypatch) -> None:
 
     assert len(calls) == 1
     assert calls[0][0].composition == "H2:0.9,He:0.1"
-    assert calls[0][0].figure.name == "h2_0p9_he_0p1_attenuation_1bar_300K_25_30cm1.png"
+    assert calls[0][0].figure.name == "h2_0p9_he_0p1_attenuation_300K_1bar_25_30cm1.png"
     assert calls[0][1] == (25.0, 30.0)
 
 
@@ -496,7 +496,7 @@ def test_plot_overview_uses_combined_default_name_without_duplicate_units(monkey
     )
 
     assert len(calls) == 1
-    assert calls[0].figure == tmp_path / "figures" / "co2_h2o_overview_0p1_100bar_170_780K_20_10000cm1.pdf"
+    assert calls[0].figure == tmp_path / "figures" / "co2_h2o_overview_170_780K_0p1_100bar_20_10000cm1.pdf"
 
 
 def test_plot_help_includes_subcommands_and_examples(capsys) -> None:


### PR DESCRIPTION
Extend pyharp-plot to accept matched temperature and pressure vectors on pressure-dependent subcommands, mirroring the dump CLI interface. Scalar plot backends remain unchanged while the top-level plot CLI now expands one task per (T,P) pair for xsection, attenuation, transmission, and overview requests.

For xsection, attenuation, and transmission, multi-state runs fan out to one figure per state pair and reuse explicit output paths by appending a temperature/pressure suffix. Overview behavior is now different by design: page computation is flattened across state pairs and wavenumber ranges in parallel, but the final result is merged back into a single PDF (and single manifest for composition overview) instead of one PDF per state.

This commit also updates the overview backends to parallelize page product computation across wn-ranges, adds regression coverage for matched vector parsing, per-state dispatch, explicit output suffixing, overview job flattening, and single-PDF overview output, and refreshes the README plus plot CLI documentation to describe the new multi-state behavior.