### PR TITLE
fix: Toon-McKay89 BC, SW bsurf, LW delta-Eddington, top_emission default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 ]
 license = { text="LICENSE" }
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
   "hitran-api",
   "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 ]
 license = { text="LICENSE" }
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 dependencies = [
   "hitran-api",
   "matplotlib",

--- a/python/csrc/pyrtsolver.cpp
+++ b/python/csrc/pyrtsolver.cpp
@@ -26,7 +26,10 @@ void bind_rtsolver(py::module& m) {
            })
       .ADD_OPTION(std::vector<double>, harp::ToonMcKay89OptionsImpl, wave_lower)
       .ADD_OPTION(std::vector<double>, harp::ToonMcKay89OptionsImpl, wave_upper)
-      .ADD_OPTION(bool, harp::ToonMcKay89OptionsImpl, zenith_correction);
+      .ADD_OPTION(bool, harp::ToonMcKay89OptionsImpl, zenith_correction)
+      .ADD_OPTION(bool, harp::ToonMcKay89OptionsImpl, hard_surface)
+      .ADD_OPTION(double, harp::ToonMcKay89OptionsImpl, top_emission)
+      .ADD_OPTION(bool, harp::ToonMcKay89OptionsImpl, delta_eddington_lw);
 
   torch::python::bind_module<harp::ToonMcKay89Impl>(m, "ToonMcKay89")
       .def(py::init<>())

--- a/src/rtsolver/rtsolver_dispatch.cpp
+++ b/src/rtsolver/rtsolver_dispatch.cpp
@@ -54,8 +54,14 @@ void call_toon89_lw_cpu(at::TensorIterator& iter) {
             auto prop = reinterpret_cast<scalar_t*>(data[1] + i * strides[1]);
             auto be = reinterpret_cast<scalar_t*>(data[2] + i * strides[2]);
             auto albedo = reinterpret_cast<scalar_t*>(data[3] + i * strides[3]);
-            toon_mckay89_longwave(nlay, be, prop, *albedo, out, len1,
-                                  work.get());
+            auto hard_surface =
+                reinterpret_cast<scalar_t*>(data[4] + i * strides[4]);
+            auto top_emission =
+                reinterpret_cast<scalar_t*>(data[5] + i * strides[5]);
+            auto delta_edd_lw =
+                reinterpret_cast<scalar_t*>(data[6] + i * strides[6]);
+            toon_mckay89_longwave(nlay, be, prop, *albedo, *hard_surface,
+                                  *top_emission, *delta_edd_lw, out, len1, work.get());
           }
         },
         grain_size);

--- a/src/rtsolver/rtsolver_dispatch.cpp
+++ b/src/rtsolver/rtsolver_dispatch.cpp
@@ -61,7 +61,8 @@ void call_toon89_lw_cpu(at::TensorIterator& iter) {
             auto delta_edd_lw =
                 reinterpret_cast<scalar_t*>(data[6] + i * strides[6]);
             toon_mckay89_longwave(nlay, be, prop, *albedo, *hard_surface,
-                                  *top_emission, *delta_edd_lw, out, len1, work.get());
+                                  *top_emission, *delta_edd_lw, out, len1,
+                                  work.get());
           }
         },
         grain_size);

--- a/src/rtsolver/rtsolver_dispatch.cu
+++ b/src/rtsolver/rtsolver_dispatch.cu
@@ -42,14 +42,18 @@ void call_toon89_lw_cuda(at::TensorIterator& iter) {
     int len1 = at::native::ensure_nonempty_size(iter.input(0), -1);
     int mem_size = toon89_lw_space<scalar_t>(nlay);
 
-    native::gpu_chunk_kernel<8, 4>(
+    native::gpu_chunk_kernel<8, 7>(
         iter, mem_size, [=] GPU_LAMBDA(
-          char* const data[4], unsigned int strides[4], char *work) {
+          char* const data[7], unsigned int strides[7], char *work) {
           auto out = reinterpret_cast<scalar_t*>(data[0] + strides[0]);
           auto prop = reinterpret_cast<scalar_t*>(data[1] + strides[1]);
           auto be = reinterpret_cast<scalar_t*>(data[2] + strides[2]);
           auto albedo = reinterpret_cast<scalar_t*>(data[3] + strides[3]);
-          toon_mckay89_longwave(nlay, be, prop, *albedo, out, len1, work);
+          auto hard_surface = reinterpret_cast<scalar_t*>(data[4] + strides[4]);
+          auto top_emission = reinterpret_cast<scalar_t*>(data[5] + strides[5]);
+          auto delta_edd_lw = reinterpret_cast<scalar_t*>(data[6] + strides[6]);
+          toon_mckay89_longwave(nlay, be, prop, *albedo, *hard_surface,
+                                *top_emission, *delta_edd_lw, out, len1, work);
         });
   });
 }

--- a/src/rtsolver/toon_mckay89.cpp
+++ b/src/rtsolver/toon_mckay89.cpp
@@ -122,6 +122,18 @@ torch::Tensor ToonMcKay89Impl::forward(torch::Tensor prop,
                     .add_input(prop)
                     .add_input(be)
                     .add_owned_input(bc->at("albedo").view({nwave, ncol, 1, 1}))
+                    .add_owned_input(
+                        torch::full({nwave, ncol, 1, 1},
+                                    options->hard_surface() ? 1.0 : 0.0,
+                                    prop.options()))
+                    .add_owned_input(
+                        torch::full({nwave, ncol, 1, 1},
+                                    options->top_emission(),
+                                    prop.options()))
+                    .add_owned_input(
+                        torch::full({nwave, ncol, 1, 1},
+                                    options->delta_eddington_lw() ? 1.0 : 0.0,
+                                    prop.options()))
                     .build();
 
     at::native::call_toon89_lw(flx.device().type(), iter);

--- a/src/rtsolver/toon_mckay89.cpp
+++ b/src/rtsolver/toon_mckay89.cpp
@@ -113,28 +113,25 @@ torch::Tensor ToonMcKay89Impl::forward(torch::Tensor prop,
 
     auto be = bbflux_wavenumber(wave_lo, wave_hi, temf.value());
 
-    auto iter = at::TensorIteratorConfig()
-                    .resize_outputs(false)
-                    .check_all_same_dtype(true)
-                    .declare_static_shape({nwave, ncol, nlyr + 1, 2},
-                                          /*squash_dims=*/{2, 3})
-                    .add_output(flx)
-                    .add_input(prop)
-                    .add_input(be)
-                    .add_owned_input(bc->at("albedo").view({nwave, ncol, 1, 1}))
-                    .add_owned_input(
-                        torch::full({nwave, ncol, 1, 1},
-                                    options->hard_surface() ? 1.0 : 0.0,
-                                    prop.options()))
-                    .add_owned_input(
-                        torch::full({nwave, ncol, 1, 1},
-                                    options->top_emission(),
-                                    prop.options()))
-                    .add_owned_input(
-                        torch::full({nwave, ncol, 1, 1},
-                                    options->delta_eddington_lw() ? 1.0 : 0.0,
-                                    prop.options()))
-                    .build();
+    auto iter =
+        at::TensorIteratorConfig()
+            .resize_outputs(false)
+            .check_all_same_dtype(true)
+            .declare_static_shape({nwave, ncol, nlyr + 1, 2},
+                                  /*squash_dims=*/{2, 3})
+            .add_output(flx)
+            .add_input(prop)
+            .add_input(be)
+            .add_owned_input(bc->at("albedo").view({nwave, ncol, 1, 1}))
+            .add_owned_input(torch::full({nwave, ncol, 1, 1},
+                                         options->hard_surface() ? 1.0 : 0.0,
+                                         prop.options()))
+            .add_owned_input(torch::full(
+                {nwave, ncol, 1, 1}, options->top_emission(), prop.options()))
+            .add_owned_input(torch::full(
+                {nwave, ncol, 1, 1}, options->delta_eddington_lw() ? 1.0 : 0.0,
+                prop.options()))
+            .build();
 
     at::native::call_toon89_lw(flx.device().type(), iter);
     return flx;

--- a/src/rtsolver/toon_mckay89.hpp
+++ b/src/rtsolver/toon_mckay89.hpp
@@ -57,7 +57,8 @@ struct ToonMcKay89OptionsImpl {
   ADD_ARG(double, top_emission) = 0.0;
 
   //! apply delta-Eddington scaling in longwave
-  //! (true = rescale w0, dtau, g as in FMS; false = use raw values as in PICASO)
+  //! (true = rescale w0, dtau, g as in FMS; false = use raw values as in
+  //! PICASO)
   ADD_ARG(bool, delta_eddington_lw) = false;
 };
 

--- a/src/rtsolver/toon_mckay89.hpp
+++ b/src/rtsolver/toon_mckay89.hpp
@@ -23,6 +23,9 @@ struct ToonMcKay89OptionsImpl {
   }
   void report(std::ostream& os) const {
     os << "* zenith_correction = " << zenith_correction() << "\n";
+    os << "* hard_surface = " << hard_surface() << "\n";
+    os << "* top_emission = " << top_emission() << "\n";
+    os << "* delta_eddington_lw = " << delta_eddington_lw() << "\n";
 
     os << "* wave_lower = ";
     for (auto const& v : wave_lower()) os << v << ", ";
@@ -41,6 +44,21 @@ struct ToonMcKay89OptionsImpl {
 
   //! zenith correction
   ADD_ARG(bool, zenith_correction) = false;
+
+  //! hard surface (true = terrestrial with emissivity BC,
+  //!               false = gas giant with Planck gradient BC)
+  ADD_ARG(bool, hard_surface) = false;
+
+  //! top emission factor
+  //!   0.0 = no incoming radiation at TOA (Toon 1989 default, GCM mode)
+  //!   1.0 = full Planck at TOA (infinite isothermal slab above)
+  //!  -1.0 = auto-compute from first layer: tau_top = dtau[0]*exp(-1),
+  //!         Btop = (1-exp(-tau_top/mu)) * B(T_top)  (FMS-style)
+  ADD_ARG(double, top_emission) = 0.0;
+
+  //! apply delta-Eddington scaling in longwave
+  //! (true = rescale w0, dtau, g as in FMS; false = use raw values as in PICASO)
+  ADD_ARG(bool, delta_eddington_lw) = false;
 };
 
 using ToonMcKay89Options = std::shared_ptr<ToonMcKay89OptionsImpl>;

--- a/src/rtsolver/toon_mckay89_longwave_impl.h
+++ b/src/rtsolver/toon_mckay89_longwave_impl.h
@@ -25,9 +25,8 @@ namespace harp {
 template <typename T>
 DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
                                           T a_surf_in, T hard_surface_in,
-                                          T top_emission_in,
-                                          T delta_edd_lw_in, T* flx, int len1,
-                                          char* work) {
+                                          T top_emission_in, T delta_edd_lw_in,
+                                          T* flx, int len1, char* work) {
   int nlev = nlay + 1;
   int l = 2 * nlay;
   int lm2 = l - 2;

--- a/src/rtsolver/toon_mckay89_longwave_impl.h
+++ b/src/rtsolver/toon_mckay89_longwave_impl.h
@@ -24,7 +24,9 @@ namespace harp {
 
 template <typename T>
 DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
-                                          T a_surf_in, T* flx, int len1,
+                                          T a_surf_in, T hard_surface_in,
+                                          T top_emission_in,
+                                          T delta_edd_lw_in, T* flx, int len1,
                                           char* work) {
   int nlev = nlay + 1;
   int l = 2 * nlay;
@@ -35,6 +37,9 @@ DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
   const int nmu = 5;
   const T twopi = 2.0 * M_PI;
   const T ubari = 0.5;
+  const bool hard_surface = (hard_surface_in > 0.5);
+  const T top_emission = top_emission_in;
+  const bool delta_eddington_lw = (delta_edd_lw_in > 0.5);
 
   const T uarr[] = {0.0985350858, 0.3045357266, 0.5620251898, 0.8019865821,
                     0.9601901429};
@@ -86,12 +91,20 @@ DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
   T* lw_up_g = alloc_from<T>(work, nlev);
   T* lw_down_g = alloc_from<T>(work, nlev);
 
-  // Delta-Eddington Scaling
+  // Delta-Eddington scaling for longwave: configurable.
+  // When enabled (delta_eddington_lw=true), rescale w0, dtau, g as in FMS.
+  // When disabled (default), use raw values as in PICASO.
   for (int i = 0; i < nlay; i++) {
-    T gsq = G_IN(i) * G_IN(i);
-    w0[i] = (1.0 - gsq) * W_IN(i) / (1.0 - W_IN(i) * gsq);
-    dtau[i] = (1.0 - W_IN(i) * gsq) * DTAU_IN(i);
-    hg[i] = G_IN(i) / (1.0 + G_IN(i));
+    if (delta_eddington_lw) {
+      T g_sq = G_IN(i) * G_IN(i);
+      w0[i] = ((1.0 - g_sq) * W_IN(i)) / (1.0 - W_IN(i) * g_sq);
+      dtau[i] = (1.0 - W_IN(i) * g_sq) * DTAU_IN(i);
+      hg[i] = G_IN(i) / (1.0 + G_IN(i));
+    } else {
+      w0[i] = W_IN(i);
+      dtau[i] = DTAU_IN(i);
+      hg[i] = G_IN(i);
+    }
   }
 
   tau[0] = 0.0;
@@ -133,9 +146,31 @@ DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
     E4[k] = gam[k] * Ep[k] - Em[k];
   }
 
-  T Btop = BE_IN(0);
+  // Top boundary: controlled by top_emission factor
+  // top_emission = 0.0: no incoming radiation at TOA (Toon 1989 default)
+  // top_emission = 1.0: full Planck at TOA (infinite isothermal slab above)
+  // top_emission < 0: auto-compute from first layer optical depth (FMS-style)
+  //   tau_top = dtau[0] * exp(-1), Btop = (1-exp(-tau_top/ubari)) * BE(0)
+  T Btop;
+  if (top_emission < 0.0) {
+    T tautop = dtau[0] * exp(-1.0);
+    Btop = (1.0 - exp(-tautop / ubari)) * BE_IN(0);
+  } else {
+    Btop = top_emission * BE_IN(0);
+  }
   T Bsurf = BE_IN(nlev - 1);
-  T bsurf_flux = Bsurf;  // Bsurf is local variable
+
+  // Bottom boundary condition depends on surface type:
+  // Gas giant (hard_surface=false): Planck + gradient extrapolation below
+  //   allows internal heat flux to emerge (matches PICASO hard_surface=0)
+  // Terrestrial (hard_surface=true): emissivity * Planck
+  //   surface emits as blackbody reduced by emissivity = 1 - albedo
+  T bsurf_flux;
+  if (hard_surface) {
+    bsurf_flux = (1.0 - a_surf_in) * Bsurf;
+  } else {
+    bsurf_flux = Bsurf + B1[nlay - 1] * ubari;
+  }
 
   // --- Matrix Construction (1-based indices for solver) ---
   Af[0] = 0.0;
@@ -209,7 +244,15 @@ DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
     T u = uarr[m];
 
     // Downward loop
-    lw_down_g[0] = twopi * Btop;
+    // Top BC: for auto-compute mode, use angle-dependent tau_top
+    T Btop_g;
+    if (top_emission < 0.0) {
+      T tautop = dtau[0] * exp(-1.0);
+      Btop_g = (1.0 - exp(-tautop / u)) * BE_IN(0);
+    } else {
+      Btop_g = top_emission * BE_IN(0);
+    }
+    lw_down_g[0] = twopi * Btop_g;
     for (int k = 0; k < nlay; k++) {
       T em2 = exp(-dtau[k] / u);
       T l_u_p1 = lam[k] * u + 1.0;
@@ -222,7 +265,14 @@ DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
     }
 
     // Upward loop
-    lw_up_g[nlev - 1] = twopi * (Bsurf + B1[nlay - 1] * u);
+    // Bottom BC for intensity sweep matches the tridiagonal BC:
+    // Gas giant: I_up = 2*pi*(B_surf + B1*u) [Planck + gradient]
+    // Terrestrial: I_up = 2*pi*(1-albedo)*B_surf [emissivity * Planck]
+    if (hard_surface) {
+      lw_up_g[nlev - 1] = twopi * (1.0 - a_surf_in) * Bsurf;
+    } else {
+      lw_up_g[nlev - 1] = twopi * (Bsurf + B1[nlay - 1] * u);
+    }
     for (int k = nlay - 1; k >= 0; k--) {
       T em2 = exp(-dtau[k] / u);
       T em3 = em1[k] * em2;

--- a/src/rtsolver/toon_mckay89_shortwave_impl.h
+++ b/src/rtsolver/toon_mckay89_shortwave_impl.h
@@ -61,7 +61,7 @@ DISPATCH_MACRO void toon_mckay89_shortwave(int nlay, T F0_in, T const* mu_in,
 
   const T sqrt3 = sqrt(3.0);
   const T sqrt3d2 = sqrt3 / 2.0;
-  const T btop = 0.0, bsurf = 0.0;
+  const T btop = 0.0;
 
   // Check for zero albedo
   bool all_zero_w = true;
@@ -181,6 +181,9 @@ DISPATCH_MACRO void toon_mckay89_shortwave(int nlay, T F0_in, T const* mu_in,
                   E1[n_idx] * (Cm[n_idx] - Cmm1[n_idx + 1]);
       n_idx++;
     }
+    // Bottom boundary: surface reflects both diffuse and direct beam.
+    // bsurf = surface albedo * direct beam flux at surface (Toon89 Eqn 37)
+    T bsurf = w_surf_in * dir[nlev - 1];
     Af[l - 1] = E1[nlay - 1] - w_surf_in * E3[nlay - 1];
     Bf[l - 1] = E2[nlay - 1] - w_surf_in * E4[nlay - 1];
     Cf[l - 1] = 0.0;


### PR DESCRIPTION
Changes:
1. SW bsurf: bottom surface term = w_surf * direct_beam (was 0)
2. LW bottom BC: gas giant B+B1*mu, terrestrial (1-a)*B
3. LW delta-Eddington: configurable option (default off)
4. top_emission default: 0.0 (was 1.0), matching Toon89 'no diffuse from above'
5. top_emission < 0: auto-compute FMS-style tau_top from first layer

Validation:
- LW thick: pyharp vs PICASO 0.6-2.9% (angular quadrature, not a bug)
- LW thick: pyharp vs FMS-Toon 0.3-0.5%
- SW: pyharp vs PICASO/FMS = 0.00%
- LW thin 14%: confirmed 100% from angular quadrature (5-pt Gauss vs single-mu)