### PR TITLE
Remove cia-index-url override from spectra tooling

### DIFF
--- a/docs/source/plot_cli.rst
+++ b/docs/source/plot_cli.rst
@@ -151,9 +151,6 @@ Shared Options
 ``--refresh-hitran`` and ``--refresh-cia``
     Re-download cached HITRAN line or CIA data.
 
-``--cia-index-url url``
-    HITRAN CIA index URL. The default is ``https://hitran.org/cia/``.
-
 ``--output path``
     Explicit output path. Use ``.png`` for single plots and ``.pdf`` for
     overview plots.

--- a/python/spectra/atm_overview_cli.py
+++ b/python/spectra/atm_overview_cli.py
@@ -274,7 +274,6 @@ def compute_mixture_overview_products(args: argparse.Namespace, *, wn_range: tup
             cache_dir=args.hitran_dir,
             filename=cia_filename,
             pair=config.cia_pair,
-            index_url=str(args.cia_index_url),
             refresh=bool(args.refresh_cia),
         )
         binary = cia_dataset.interpolate_to_grid(temperature_k, grid)
@@ -303,7 +302,6 @@ def compute_mixture_overview_products(args: argparse.Namespace, *, wn_range: tup
             cache_dir=args.hitran_dir,
             filename=filename,
             pair=pair_name,
-            index_url=str(args.cia_index_url),
             refresh=bool(args.refresh_cia),
         )
         binary = cia_dataset.interpolate_to_grid(temperature_k, grid)
@@ -544,7 +542,6 @@ def build_atm_overview_parser() -> argparse.ArgumentParser:
     parser.add_argument("--resolution", type=float, default=1.0)
     parser.add_argument("--wn-range", dest="wn_ranges", action="append", type=_parse_wn_range, required=True)
     parser.add_argument("--broadening-composition", default=None)
-    parser.add_argument("--cia-index-url", default="https://hitran.org/cia/")
     parser.add_argument("--refresh-hitran", action="store_true")
     parser.add_argument("--refresh-cia", action="store_true")
     parser.add_argument("--figure", type=Path, default=Path("output/atm_overview.pdf"))

--- a/python/spectra/config.py
+++ b/python/spectra/config.py
@@ -294,7 +294,6 @@ class SpectroscopyConfig:
     species_name: str = "CO2"
     isotopologue_ids: tuple[int, ...] | None = None
     broadening_composition: dict[str, float] | str | None = None
-    cia_index_url: str = "https://hitran.org/cia/"
     refresh_hitran: bool = False
     min_line_strength: float = 1.0e-27
 

--- a/python/spectra/dump_cli.py
+++ b/python/spectra/dump_cli.py
@@ -111,7 +111,6 @@ def _add_common_arguments(parser: argparse.ArgumentParser, *, include_path_lengt
     parser.add_argument("--cia-dir", type=Path, default=None, metavar="DIR", help="Directory for alternate CIA tables. HITRAN uses --hitran-dir; xiz/orton use orton_xiz_cia/ by default.")
     parser.add_argument("--cia-model", choices=("auto", "2011", "2018", "xiz", "orton"), default="auto", help="CIA model selector. auto/2011/2018 use HITRAN. xiz/orton use the legacy Orton/Xiz tables.")
     parser.add_argument("--h2-state", choices=("eq", "nm"), default="eq", help="H2 spin-state selector used by HITRAN 2018 and xiz/orton H2 tables.")
-    parser.add_argument("--cia-index-url", default="https://hitran.org/cia/", metavar="URL", help="HITRAN CIA index URL used to resolve CIA files.")
     parser.add_argument("--refresh-cia", action="store_true", help="Re-download HITRAN CIA files even if cached.")
     if include_path_length:
         parser.add_argument("--path-length-km", type=float, default=1.0, metavar="KM", help=TRANSMISSION_PATH_LENGTH_HELP)
@@ -610,7 +609,6 @@ def _load_pair_cia_dataset(args: argparse.Namespace):
         cache_dir=args.hitran_dir,
         filename=filename,
         pair=pair,
-        index_url=str(args.cia_index_url),
         refresh=bool(args.refresh_cia),
     )
 
@@ -637,7 +635,6 @@ def _resolve_species_cia(args: argparse.Namespace, config: SpectroscopyConfig):
         cache_dir=args.hitran_dir,
         filename=filename,
         pair=pair,
-        index_url=str(args.cia_index_url),
         refresh=bool(args.refresh_cia),
     )
 
@@ -751,7 +748,6 @@ def _compute_composition_products(args: argparse.Namespace):
         temperature_k=temperature_k,
         pressure_bar=pressure_bar,
         resolution=args.resolution,
-        cia_index_url=args.cia_index_url,
         refresh_hitran=args.refresh_hitran,
         refresh_cia=args.refresh_cia,
         broadening_composition=args.broadening_composition,

--- a/python/spectra/hitran_cia.py
+++ b/python/spectra/hitran_cia.py
@@ -14,6 +14,7 @@ from .blackbody import compute_normalized_blackbody_curve
 from .config import SpectroscopyConfig
 
 K_BOLTZMANN = 1.380649e-23
+HITRAN_CIA_INDEX_URL = "https://hitran.org/cia/"
 
 
 class _HrefCollector(HTMLParser):
@@ -110,23 +111,22 @@ def _download_text(url: str) -> str:
         return response.read().decode("utf-8")
 
 
-def find_cia_download_url(index_url: str, filename: str) -> str:
+def find_cia_download_url(filename: str) -> str:
     """Resolve the CIA download URL by scraping the HITRAN CIA index page."""
-    html = _download_text(index_url)
+    html = _download_text(HITRAN_CIA_INDEX_URL)
     parser = _HrefCollector()
     parser.feed(html)
     filename_lower = filename.lower()
     for href in parser.hrefs:
         if filename_lower in href.lower():
-            return urljoin(index_url, href)
-    return urljoin(index_url, filename)
+            return urljoin(HITRAN_CIA_INDEX_URL, href)
+    return urljoin(HITRAN_CIA_INDEX_URL, filename)
 
 
 def download_cia_file_by_name(
     *,
     cache_dir: Path,
     filename: str,
-    index_url: str = "https://hitran.org/cia/",
     refresh: bool = False,
 ) -> Path:
     """Download a named CIA file into the requested local cache directory."""
@@ -134,7 +134,7 @@ def download_cia_file_by_name(
     target = cache_dir / filename
     if target.exists() and not refresh:
         return target
-    url = find_cia_download_url(index_url, filename)
+    url = find_cia_download_url(filename)
     req = Request(url, headers={"User-Agent": "spectra/0.1"})
     with urlopen(req) as response, open(target, "wb") as handle:
         handle.write(response.read())
@@ -147,7 +147,6 @@ def download_cia_file(config: SpectroscopyConfig) -> Path:
     return download_cia_file_by_name(
         cache_dir=config.hitran_cache_dir,
         filename=config.cia_filename,
-        index_url=config.cia_index_url,
         refresh=config.refresh_hitran,
     )
 
@@ -223,14 +222,12 @@ def load_cia_dataset(
     cache_dir: Path,
     filename: str,
     pair: str,
-    index_url: str = "https://hitran.org/cia/",
     refresh: bool = False,
 ) -> CiaDataset:
     """Download and parse a CIA dataset identified by filename and pair."""
     path = download_cia_file_by_name(
         cache_dir=cache_dir,
         filename=filename,
-        index_url=index_url,
         refresh=refresh,
     )
     return parse_cia_file(path, pair)

--- a/python/spectra/molecule_plot_cli.py
+++ b/python/spectra/molecule_plot_cli.py
@@ -59,7 +59,6 @@ def _add_common_arguments(parser: argparse.ArgumentParser, *, include_state: boo
 def _add_external_cia_arguments(parser: argparse.ArgumentParser, *, required: bool = False) -> None:
     parser.add_argument("--cia-filename", required=required)
     parser.add_argument("--cia-pair", default=None)
-    parser.add_argument("--cia-index-url", default="https://hitran.org/cia/")
     parser.add_argument("--refresh-cia", action="store_true")
 
 
@@ -116,7 +115,6 @@ def _load_requested_cia_dataset(args: argparse.Namespace, config: SpectroscopyCo
         cache_dir=args.hitran_dir,
         filename=cia_filename,
         pair=_resolve_cia_pair(args, config),
-        index_url=str(args.cia_index_url),
         refresh=bool(args.refresh_cia),
     )
 
@@ -595,7 +593,6 @@ def build_molecule_overview_batch_parser() -> argparse.ArgumentParser:
     parser.add_argument("--wn-range", dest="wn_ranges", action="append", type=_parse_wn_range, required=True)
     parser.add_argument("--refresh-hitran", action="store_true")
     parser.add_argument("--broadening-composition", default=None)
-    parser.add_argument("--cia-index-url", default="https://hitran.org/cia/")
     parser.add_argument("--refresh-cia", action="store_true")
     parser.add_argument("--figure", type=Path, default=Path("output/molecule_overview_collection.pdf"))
     return parser
@@ -627,7 +624,6 @@ def run_overview_batch(args: argparse.Namespace) -> None:
                     broadening_composition=args.broadening_composition,
                     cia_filename=None,
                     cia_pair=None,
-                    cia_index_url=args.cia_index_url,
                     refresh_cia=args.refresh_cia,
                     path_length_km=args.path_length_km,
                     figure=figure_path,

--- a/python/spectra/plot_cli.py
+++ b/python/spectra/plot_cli.py
@@ -81,7 +81,6 @@ def _add_common_arguments(parser: argparse.ArgumentParser, *, allow_multiple_ran
 
 def _add_cache_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--refresh-hitran", action="store_true", help="Re-download HITRAN line tables even if cached.")
-    parser.add_argument("--cia-index-url", default="https://hitran.org/cia/", metavar="URL", help="HITRAN CIA index URL used to resolve CIA files.")
     parser.add_argument("--refresh-cia", action="store_true", help="Re-download HITRAN CIA files even if cached.")
 
 
@@ -197,7 +196,6 @@ def _as_cia_args(args: argparse.Namespace, *, default_pair: str, plot_type: str)
         resolution=args.resolution,
         refresh=refresh_cia,
         refresh_cia=refresh_cia,
-        cia_index_url=getattr(args, "cia_index_url", None),
         pressure_bar=pressure_bar,
         path_length_km=getattr(args, "path_length_km", 1.0),
         figure=args.figure
@@ -225,7 +223,6 @@ def _as_molecule_args(args: argparse.Namespace, *, plot_type: str) -> argparse.N
         refresh_hitran=args.refresh_hitran,
         cia_filename=getattr(args, "cia_filename", None),
         cia_pair=getattr(args, "cia_pair", None),
-        cia_index_url=args.cia_index_url,
         refresh_cia=args.refresh_cia,
         broadening_composition=getattr(args, "broadening_composition", None),
         path_length_km=getattr(args, "path_length_km", 1.0),
@@ -252,7 +249,6 @@ def _as_molecule_overview_args(args: argparse.Namespace, *, species: str, wn_ran
         refresh_hitran=args.refresh_hitran,
         cia_filename=getattr(args, "cia_filename", None),
         cia_pair=getattr(args, "cia_pair", None),
-        cia_index_url=args.cia_index_url,
         refresh_cia=args.refresh_cia,
         broadening_composition=getattr(args, "broadening_composition", None),
         path_length_km=args.path_length_km,
@@ -279,7 +275,6 @@ def _as_molecule_overview_batch_args(args: argparse.Namespace, *, species: list[
         path_length_km=args.path_length_km,
         wn_ranges=wn_ranges,
         refresh_hitran=args.refresh_hitran,
-        cia_index_url=args.cia_index_url,
         refresh_cia=args.refresh_cia,
         broadening_composition=getattr(args, "broadening_composition", None),
         figure=args.figure
@@ -304,7 +299,6 @@ def _as_atm_overview_args(args: argparse.Namespace, *, wn_ranges: list[tuple[flo
         path_length_km=args.path_length_km,
         resolution=args.resolution,
         wn_ranges=wn_ranges,
-        cia_index_url=args.cia_index_url,
         refresh_hitran=args.refresh_hitran,
         refresh_cia=args.refresh_cia,
         broadening_composition=getattr(args, "broadening_composition", None),
@@ -331,7 +325,6 @@ def _as_atm_args(args: argparse.Namespace, *, plot_type: str, wn_range: tuple[fl
         path_length_km=getattr(args, "path_length_km", 1.0),
         resolution=args.resolution,
         wn_range=wn_range,
-        cia_index_url=args.cia_index_url,
         refresh_hitran=args.refresh_hitran,
         refresh_cia=args.refresh_cia,
         broadening_composition=getattr(args, "broadening_composition", None),

--- a/tests/spectra/test_molecule_plot_cli.py
+++ b/tests/spectra/test_molecule_plot_cli.py
@@ -255,7 +255,6 @@ def test_run_xsection_reports_broadening_summary(monkeypatch, tmp_path, capsys) 
         refresh_hitran=False,
         cia_filename=None,
         cia_pair=None,
-        cia_index_url="https://hitran.org/cia/",
         refresh_cia=False,
         figure=tmp_path / "co2.png",
     )


### PR DESCRIPTION
Drop the user-facing --cia-index-url option from the spectra CLIs and remove the matching cia_index_url field from SpectroscopyConfig.

The HITRAN CIA downloader now uses a single internal default index URL, so the surrounding loaders and argparse namespace plumbing no longer need to thread a configurable index through pair, species, molecule overview, and atmosphere overview workflows.

Also remove the obsolete plot CLI documentation entry and update the affected molecule CLI test fixture to match the new argument surface.