### PR TITLE
Toon89: add layer-midpoint flux output and a configurable top-emission factor

### DIFF
--- a/src/radiation/flux_utils.cpp
+++ b/src/radiation/flux_utils.cpp
@@ -25,7 +25,8 @@ torch::Tensor sum_spectrum(torch::Tensor flux, torch::Tensor wave_or_weight,
 }
 
 torch::Tensor cal_net_flux(torch::Tensor flux) {
-  // Last dimension is >=2: [0]=up, [1]=down (+ optional [2,3]=midpoint up/down).
+  // Last dimension is >=2: [0]=up, [1]=down (+ optional [2,3]=midpoint
+  // up/down).
   TORCH_CHECK(flux.size(-1) >= 2, "flux must have last dimension of size >= 2");
   return flux.select(-1, disort::IUP) - flux.select(-1, disort::IDN);
 }

--- a/src/radiation/flux_utils.cpp
+++ b/src/radiation/flux_utils.cpp
@@ -25,21 +25,30 @@ torch::Tensor sum_spectrum(torch::Tensor flux, torch::Tensor wave_or_weight,
 }
 
 torch::Tensor cal_net_flux(torch::Tensor flux) {
-  // Check last dimension
-  TORCH_CHECK(flux.size(-1) == 2, "flux must have last dimension of size 2");
+  // Last dimension is >=2: [0]=up, [1]=down (+ optional [2,3]=midpoint up/down).
+  TORCH_CHECK(flux.size(-1) >= 2, "flux must have last dimension of size >= 2");
   return flux.select(-1, disort::IUP) - flux.select(-1, disort::IDN);
 }
 
 torch::Tensor cal_surface_flux(torch::Tensor flux) {
   // Check last dimension
-  TORCH_CHECK(flux.size(-1) == 2, "flux must have last dimension of size 2");
+  TORCH_CHECK(flux.size(-1) >= 2, "flux must have last dimension of size >= 2");
   return flux.select(-1, disort::IDN).select(-1, 0);
 }
 
 torch::Tensor cal_toa_flux(torch::Tensor flux) {
   // Check last dimension
-  TORCH_CHECK(flux.size(-1) == 2, "flux must have last dimension of size 2");
+  TORCH_CHECK(flux.size(-1) >= 2, "flux must have last dimension of size >= 2");
   return flux.select(-1, disort::IUP).select(-1, -1);
+}
+
+torch::Tensor cal_net_flux_midpt(torch::Tensor flux) {
+  // Net flux at layer MIDPOINTS, from channels [2]=mid up, [3]=mid down.
+  // Used by the 1D RCE solver for a staggered (collocation-shift) residual
+  // that avoids the period-2 interface-flux null mode.
+  TORCH_CHECK(flux.size(-1) >= 4,
+              "midpoint net flux needs last dimension of size >= 4");
+  return flux.select(-1, 2) - flux.select(-1, 3);
 }
 
 torch::Tensor spherical_flux_scaling(torch::Tensor flx, torch::Tensor dz,

--- a/src/radiation/flux_utils.hpp
+++ b/src/radiation/flux_utils.hpp
@@ -92,6 +92,19 @@ torch::Tensor cal_surface_flux(torch::Tensor flux);
  */
 torch::Tensor cal_toa_flux(torch::Tensor flux);
 
+//! \brief Calculate net flux at layer midpoints
+/*!
+ * Uses channels [2]=midpoint up and [3]=midpoint down of the flux tensor
+ * (last dimension must be >= 4). The Toon longwave solver fills these with the
+ * flux evaluated at half-layer optical depth (PICASO flux_*_mdpt). The 1D RCE
+ * solver drives this STAGGERED quantity (instead of the collocated interface
+ * net flux) to avoid the period-2 odd-even decoupling null mode.
+ *
+ * \param flux The flux tensor (..., nlev, >=4)
+ * \return The layer-midpoint net flux (..., nlev)
+ */
+torch::Tensor cal_net_flux_midpt(torch::Tensor flux);
+
 //! \brief Spherical correction by XIZ
 /*!
  * Formula 1:

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -64,6 +64,10 @@ void RadiationImpl::reset() {
 
   // spectra holder
   spectra = register_buffer("spectra", torch::tensor({0}, torch::kFloat64));
+
+  // midpoint net flux holder (set during forward, read by the 1D RCE solver)
+  net_flux_midpt =
+      register_buffer("net_flux_midpt", torch::tensor({0}, torch::kFloat64));
 }
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> RadiationImpl::forward(
@@ -87,6 +91,10 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> RadiationImpl::forward(
   spectra.set_(torch::stack(spectrum, 0));
 
   auto net_flux = cal_net_flux(total_flux);
+
+  // stash the layer-midpoint net flux (channels [2,3] of total_flux) for the
+  // 1D RCE solver's staggered residual. The returned 3-tuple is unchanged.
+  net_flux_midpt.set_(cal_net_flux_midpt(total_flux));
 
   // doing spherical scaling
   if (kwargs->find("area") != kwargs->end()) {

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -100,6 +100,12 @@ class RadiationImpl : public torch::nn::Cloneable<RadiationImpl> {
   //! band spectra
   torch::Tensor spectra;
 
+  //! net flux at layer midpoints (ncol, nlev), set during forward().
+  //! Read by the 1D RCE solver for its staggered (midpoint-flux) residual;
+  //! the 3-tuple return of forward() is unchanged so other callers are
+  //! unaffected. For non-Toon bands this falls back to the level net flux.
+  torch::Tensor net_flux_midpt;
+
   //! all RadiationBands
   std::vector<RadiationBand> bands;
 

--- a/src/radiation/radiation_band.cpp
+++ b/src/radiation/radiation_band.cpp
@@ -118,6 +118,8 @@ RadiationBandOptions RadiationBandOptionsImpl::from_yaml(
       auto const toon = band["toon"];
       op->toon()->top_emission_flag(
           toon["top_emission_flag"].as<int>(op->toon()->top_emission_flag()));
+      op->toon()->btop_factor(
+          toon["btop_factor"].as<double>(op->toon()->btop_factor()));
       if (toon["flags"]) {
         op->toon()->flags(trim_copy(toon["flags"].as<std::string>()));
       }

--- a/src/radiation/radiation_band.cpp
+++ b/src/radiation/radiation_band.cpp
@@ -385,6 +385,15 @@ torch::Tensor RadiationBandImpl::forward(
         spectrum, torch::tensor(options->wavenumber(), spectrum.options()),
         "wavenumber");
   }
+  // Ensure a uniform 4-channel layout [up, down, mid_up, mid_down] across all
+  // bands so band fluxes can be summed regardless of solver. The Toon solver
+  // already emits 4 channels (level + layer-midpoint). Other solvers (disort,
+  // beer-lambert) emit 2 (level only); duplicate the level channels into the
+  // midpoint slots so their midpoint net flux falls back to the level net flux
+  // (harmless: only the 1D RCE reads the midpoint, and it uses Toon bands).
+  if (result.size(-1) < 4) {
+    result = torch::cat({result, result}, -1);
+  }
   return result;
 }
 

--- a/src/rtsolver/rtsolver_dispatch.cpp
+++ b/src/rtsolver/rtsolver_dispatch.cpp
@@ -16,8 +16,8 @@
 namespace harp {
 
 void call_toon89_sw_cpu(at::TensorIterator& iter, bool zenith_correction,
-                        int /*top_emission_flag*/, bool /*hard_surface*/,
-                        bool /*delta_eddington_lw*/) {
+                        int /*top_emission_flag*/, double /*btop_factor*/,
+                        bool /*hard_surface*/, bool /*delta_eddington_lw*/) {
   AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "call_toon89_sw_cpu", [&] {
     int nlay = at::native::ensure_nonempty_size(iter.input(0), -2);
     int len1 = at::native::ensure_nonempty_size(iter.input(0), -1);
@@ -42,8 +42,8 @@ void call_toon89_sw_cpu(at::TensorIterator& iter, bool zenith_correction,
 }
 
 void call_toon89_lw_cpu(at::TensorIterator& iter, bool /*zenith_correction*/,
-                        int top_emission_flag, bool hard_surface,
-                        bool delta_eddington_lw) {
+                        int top_emission_flag, double btop_factor,
+                        bool hard_surface, bool delta_eddington_lw) {
   AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "call_toon89_lw_cpu", [&] {
     int nlay = at::native::ensure_nonempty_size(iter.input(0), -2);
     int len1 = at::native::ensure_nonempty_size(iter.input(0), -1);
@@ -65,6 +65,7 @@ void call_toon89_lw_cpu(at::TensorIterator& iter, bool /*zenith_correction*/,
             auto delta_edd_lw =
                 reinterpret_cast<scalar_t*>(data[6] + i * strides[6]);
             toon_mckay89_longwave(nlay, be, prop, *albedo, top_emission_flag,
+                                  static_cast<scalar_t>(btop_factor),
                                   hard_surface, delta_eddington_lw, out, len1,
                                   work.get());
           }

--- a/src/rtsolver/rtsolver_dispatch.cu
+++ b/src/rtsolver/rtsolver_dispatch.cu
@@ -16,6 +16,7 @@ namespace harp {
 void call_toon89_sw_cuda(at::TensorIterator& iter,
                          bool zenith_correction,
                          int /*top_emission_flag*/,
+                         double /*btop_factor*/,
                          bool /*hard_surface*/,
                          bool /*delta_eddington_lw*/) {
   at::cuda::CUDAGuard device_guard(iter.device());
@@ -41,6 +42,7 @@ void call_toon89_sw_cuda(at::TensorIterator& iter,
 void call_toon89_lw_cuda(at::TensorIterator& iter,
                          bool /*zenith_correction*/,
                          int top_emission_flag,
+                         double btop_factor,
                          bool hard_surface,
                          bool delta_eddington_lw) {
   at::cuda::CUDAGuard device_guard(iter.device());
@@ -58,6 +60,7 @@ void call_toon89_lw_cuda(at::TensorIterator& iter,
           auto be = reinterpret_cast<scalar_t*>(data[2] + strides[2]);
           auto albedo = reinterpret_cast<scalar_t*>(data[3] + strides[3]);
           toon_mckay89_longwave(nlay, be, prop, *albedo, top_emission_flag,
+                                static_cast<scalar_t>(btop_factor),
                                 hard_surface, delta_eddington_lw, out, len1, work);
         });
   });

--- a/src/rtsolver/rtsolver_dispatch.hpp
+++ b/src/rtsolver/rtsolver_dispatch.hpp
@@ -7,8 +7,8 @@
 namespace at::native {
 
 using toon89_fn = void (*)(at::TensorIterator& iter, bool zenith_correction,
-                           int top_emission_flag, bool hard_surface,
-                           bool delta_eddington_lw);
+                           int top_emission_flag, double btop_factor,
+                           bool hard_surface, bool delta_eddington_lw);
 
 //! \brief Toon 1989 longwave solver
 /*!

--- a/src/rtsolver/toon_mckay89.cpp
+++ b/src/rtsolver/toon_mckay89.cpp
@@ -107,8 +107,8 @@ torch::Tensor ToonMcKay89Impl::forward(torch::Tensor prop,
 
     at::native::call_toon89_sw(
         flx.device().type(), iter, options->zenith_correction(),
-        options->top_emission_flag(), options->hard_surface(),
-        options->delta_eddington_lw());
+        options->top_emission_flag(), options->btop_factor(),
+        options->hard_surface(), options->delta_eddington_lw());
     return flx;
   } else {  // longwave
     TORCH_CHECK(temf.has_value(),
@@ -141,8 +141,8 @@ torch::Tensor ToonMcKay89Impl::forward(torch::Tensor prop,
 
     at::native::call_toon89_lw(
         flx.device().type(), iter, options->zenith_correction(),
-        options->top_emission_flag(), options->hard_surface(),
-        options->delta_eddington_lw());
+        options->top_emission_flag(), options->btop_factor(),
+        options->hard_surface(), options->delta_eddington_lw());
     return flx;
   }
 }

--- a/src/rtsolver/toon_mckay89.cpp
+++ b/src/rtsolver/toon_mckay89.cpp
@@ -77,7 +77,12 @@ torch::Tensor ToonMcKay89Impl::forward(torch::Tensor prop,
     (*bc)["albedo"] = torch::zeros({nwave, ncol}, prop.options());
   }
 
-  auto flx = torch::zeros({nwave, ncol, nlyr + 1, 2}, prop.options());
+  // 4 channels: [0]=level up, [1]=level down, [2]=layer-midpoint up,
+  // [3]=layer-midpoint down. The midpoint channels carry the flux at the
+  // half-layer optical depth (PICASO flux_*_mdpt), used by the 1D RCE solver
+  // for a STAGGERED residual that avoids the period-2 (collocated
+  // interface-flux) null mode. Level channels [0,1] are unchanged.
+  auto flx = torch::zeros({nwave, ncol, nlyr + 1, 4}, prop.options());
 
   // Ensure prop is contiguous so raw pointer access in impl is correct.
   // Non-contiguous slices (e.g. prop[:,:,:,:3] from a larger tensor)
@@ -88,7 +93,7 @@ torch::Tensor ToonMcKay89Impl::forward(torch::Tensor prop,
     auto iter = at::TensorIteratorConfig()
                     .resize_outputs(false)
                     .check_all_same_dtype(true)
-                    .declare_static_shape({nwave, ncol, nlyr + 1, 2},
+                    .declare_static_shape({nwave, ncol, nlyr + 1, 4},
                                           /*squash_dims=*/{2, 3})
                     .add_output(flx)
                     .add_input(prop)
@@ -126,7 +131,7 @@ torch::Tensor ToonMcKay89Impl::forward(torch::Tensor prop,
     auto iter = at::TensorIteratorConfig()
                     .resize_outputs(false)
                     .check_all_same_dtype(true)
-                    .declare_static_shape({nwave, ncol, nlyr + 1, 2},
+                    .declare_static_shape({nwave, ncol, nlyr + 1, 4},
                                           /*squash_dims=*/{2, 3})
                     .add_output(flx)
                     .add_input(prop)

--- a/src/rtsolver/toon_mckay89.hpp
+++ b/src/rtsolver/toon_mckay89.hpp
@@ -58,6 +58,7 @@ struct ToonMcKay89OptionsImpl {
     os << "* planck = " << planck() << "\n";
     os << "* zenith_correction = " << zenith_correction() << "\n";
     os << "* top_emission_flag = " << top_emission_flag() << "\n";
+    os << "* btop_factor = " << btop_factor() << "\n";
     os << "* hard_surface = " << hard_surface() << "\n";
     os << "* delta_eddington_lw = " << delta_eddington_lw() << "\n";
 
@@ -82,9 +83,17 @@ struct ToonMcKay89OptionsImpl {
   //! top emission flag
   //!   0 = no incoming radiation at TOA (Toon 1989 default, GCM mode)
   //!   1 = full Planck at TOA (infinite isothermal slab above)
-  //!  -1 = auto-compute from first layer: tau_top = dtau[0]*exp(-1),
-  //!       Btop = (1-exp(-tau_top/mu)) * B(T_top)  (FMS-style)
+  //!  -1 = auto-compute from first layer: tau_top = dtau[0]*btop_factor,
+  //!       Btop = (1-exp(-tau_top/mu)) * B(T_top)
   ADD_ARG(int, top_emission_flag) = 0;
+
+  //! factor for the auto top-emission tau_top (top_emission_flag < 0):
+  //! tau_top = dtau[0] * btop_factor. Default exp(-1) (FMS-style). Set to
+  //! plevel[0]/(plevel[1]-plevel[0]) = 1/(r-1) for a log-P grid to reproduce
+  //! PICASO's get_thermal_1d "imaginary isothermal slab above" top BC, which
+  //! warms the optically-thin skin onto PICASO (the difference is purely this
+  //! TOA boundary convention, not the RT scheme).
+  ADD_ARG(double, btop_factor) = 0.36787944117144233;
 };
 
 using ToonMcKay89Options = std::shared_ptr<ToonMcKay89OptionsImpl>;

--- a/src/rtsolver/toon_mckay89_longwave_impl.h
+++ b/src/rtsolver/toon_mckay89_longwave_impl.h
@@ -277,13 +277,12 @@ DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
       // (PICASO get_thermal_1d flux_minus_mdpt; vars: xj=J, xk=K.)
       T em2_mid = exp(-0.5 * dtau[k] / u);
       T exptrm_h = fmin(0.5 * lam[k] * dtau[k], 35.0);
-      T Ep_mid = exp(exptrm_h);    // exptrm_positive_mdpt
-      T em1_mid = 1.0 / Ep_mid;    // exptrm_minus_mdpt
-      T mid_dn = lw_down_g[k] * em2_mid +
-                 (xj[k] / l_u_p1) * (Ep_mid - em2_mid) +
-                 (xk[k] / l_u_m1) * (em2_mid - em1_mid) +
-                 sigma1[k] * (1.0 - em2_mid) +
-                 sigma2[k] * (u * em2_mid + 0.5 * dtau[k] - u);
+      T Ep_mid = exp(exptrm_h);  // exptrm_positive_mdpt
+      T em1_mid = 1.0 / Ep_mid;  // exptrm_minus_mdpt
+      T mid_dn =
+          lw_down_g[k] * em2_mid + (xj[k] / l_u_p1) * (Ep_mid - em2_mid) +
+          (xk[k] / l_u_m1) * (em2_mid - em1_mid) + sigma1[k] * (1.0 - em2_mid) +
+          sigma2[k] * (u * em2_mid + 0.5 * dtau[k] - u);
       FLX_DN_MID(k) += mid_dn * wuarr[m];
     }
 
@@ -312,8 +311,8 @@ DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
       // (PICASO get_thermal_1d flux_plus_mdpt; vars: g=G, h=H.)
       T em2_mid = exp(-0.5 * dtau[k] / u);
       T exptrm_h = fmin(0.5 * lam[k] * dtau[k], 35.0);
-      T Ep_mid = exp(exptrm_h);    // exptrm_positive_mdpt
-      T em1_mid = 1.0 / Ep_mid;    // exptrm_minus_mdpt
+      T Ep_mid = exp(exptrm_h);  // exptrm_positive_mdpt
+      T em1_mid = 1.0 / Ep_mid;  // exptrm_minus_mdpt
       T mid_up = lw_up_g[k + 1] * em2_mid +
                  (g[k] / l_u_m1) * (Ep[k] * em2_mid - Ep_mid) +
                  (h[k] / l_u_p1) * (em1_mid - em1[k] * em2_mid) +

--- a/src/rtsolver/toon_mckay89_longwave_impl.h
+++ b/src/rtsolver/toon_mckay89_longwave_impl.h
@@ -17,8 +17,15 @@
 #define W_IN(i) prop[(nlay - (i) - 1) * len1 + 1]
 #define G_IN(i) prop[(nlay - (i) - 1) * len1 + 2]
 #define BE_IN(i) be[nlev - (i) - 1]
-#define FLX_UP(i) flx[2 * (nlev - (i) - 1)]
-#define FLX_DN(i) flx[2 * (nlev - (i) - 1) + 1]
+// 4 channels per level: [0]=level up, [1]=level down,
+// [2]=layer-midpoint up, [3]=layer-midpoint down.
+#define FLX_UP(i) flx[4 * (nlev - (i) - 1)]
+#define FLX_DN(i) flx[4 * (nlev - (i) - 1) + 1]
+// Midpoint flux of internal LAYER k (between internal levels k and k+1) is
+// stored in channels [2,3] of the layer's upper-level slot (internal level k).
+// The deepest external slot (internal level nlay) holds no layer midpoint -> 0.
+#define FLX_UP_MID(k) flx[4 * (nlev - (k) - 1) + 2]
+#define FLX_DN_MID(k) flx[4 * (nlev - (k) - 1) + 3]
 
 namespace harp {
 
@@ -236,6 +243,10 @@ DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
     FLX_UP(k) = 0.0;
     FLX_DN(k) = 0.0;
   }
+  for (int k = 0; k < nlay; k++) {
+    FLX_UP_MID(k) = 0.0;
+    FLX_DN_MID(k) = 0.0;
+  }
 
   // --- Gaussian Quadrature Mu Loop ---
   for (int m = 0; m < nmu; m++) {
@@ -260,6 +271,20 @@ DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
                          (xk[k] / l_u_m1) * (em2 - em1[k]) +
                          sigma1[k] * (1.0 - em2) +
                          sigma2[k] * (u * em2 + dtau[k] - u);
+
+      // downward flux at the MIDPOINT of layer k (half-layer optical depth),
+      // same source-function form as the level update but to tau_k + dtau/2.
+      // (PICASO get_thermal_1d flux_minus_mdpt; vars: xj=J, xk=K.)
+      T em2_mid = exp(-0.5 * dtau[k] / u);
+      T exptrm_h = fmin(0.5 * lam[k] * dtau[k], 35.0);
+      T Ep_mid = exp(exptrm_h);    // exptrm_positive_mdpt
+      T em1_mid = 1.0 / Ep_mid;    // exptrm_minus_mdpt
+      T mid_dn = lw_down_g[k] * em2_mid +
+                 (xj[k] / l_u_p1) * (Ep_mid - em2_mid) +
+                 (xk[k] / l_u_m1) * (em2_mid - em1_mid) +
+                 sigma1[k] * (1.0 - em2_mid) +
+                 sigma2[k] * (u * em2_mid + 0.5 * dtau[k] - u);
+      FLX_DN_MID(k) += mid_dn * wuarr[m];
     }
 
     // Upward loop
@@ -281,6 +306,20 @@ DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
                    (g[k] / l_u_m1) * (Ep[k] * em2 - 1.0) +
                    (h[k] / l_u_p1) * (1.0 - em3) + alpha1[k] * (1.0 - em2) +
                    alpha2[k] * (u - (dtau[k] + u) * em2);
+
+      // upward flux at the MIDPOINT of layer k (half-layer optical depth),
+      // propagated up from the lower-interface level flux lw_up_g[k+1].
+      // (PICASO get_thermal_1d flux_plus_mdpt; vars: g=G, h=H.)
+      T em2_mid = exp(-0.5 * dtau[k] / u);
+      T exptrm_h = fmin(0.5 * lam[k] * dtau[k], 35.0);
+      T Ep_mid = exp(exptrm_h);    // exptrm_positive_mdpt
+      T em1_mid = 1.0 / Ep_mid;    // exptrm_minus_mdpt
+      T mid_up = lw_up_g[k + 1] * em2_mid +
+                 (g[k] / l_u_m1) * (Ep[k] * em2_mid - Ep_mid) +
+                 (h[k] / l_u_p1) * (em1_mid - em1[k] * em2_mid) +
+                 alpha1[k] * (1.0 - em2_mid) +
+                 alpha2[k] * (u + 0.5 * dtau[k] - (dtau[k] + u) * em2_mid);
+      FLX_UP_MID(k) += mid_up * wuarr[m];
     }
 
     for (int k = 0; k < nlev; k++) {
@@ -298,3 +337,5 @@ DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
 #undef BE_IN
 #undef FLX_UP
 #undef FLX_DN
+#undef FLX_UP_MID
+#undef FLX_DN_MID

--- a/src/rtsolver/toon_mckay89_longwave_impl.h
+++ b/src/rtsolver/toon_mckay89_longwave_impl.h
@@ -32,7 +32,7 @@ namespace harp {
 template <typename T>
 DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
                                           T a_surf_in, int top_emission_flag,
-                                          bool hard_surface,
+                                          T btop_factor, bool hard_surface,
                                           bool delta_eddington_lw, T* flx,
                                           int len1, char* work) {
   int nlev = nlay + 1;
@@ -158,7 +158,7 @@ DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
   //   tau_top = dtau[0] * exp(-1), Btop = (1-exp(-tau_top/ubari)) * BE(0)
   T Btop;
   if (top_emission_flag < 0) {
-    T tautop = dtau[0] * exp(-1.0);
+    T tautop = dtau[0] * btop_factor;
     Btop = (1.0 - exp(-tautop / ubari)) * BE_IN(0);
   } else {
     Btop = top_emission_flag * BE_IN(0);
@@ -256,7 +256,7 @@ DISPATCH_MACRO void toon_mckay89_longwave(int nlay, const T* be, const T* prop,
     // Top BC: for auto-compute mode, use angle-dependent tau_top
     T Btop_g;
     if (top_emission_flag < 0) {
-      T tautop = dtau[0] * exp(-1.0);
+      T tautop = dtau[0] * btop_factor;
       Btop_g = (1.0 - exp(-tautop / u)) * BE_IN(0);
     } else {
       Btop_g = top_emission_flag * BE_IN(0);

--- a/src/rtsolver/toon_mckay89_shortwave_impl.h
+++ b/src/rtsolver/toon_mckay89_shortwave_impl.h
@@ -14,8 +14,13 @@
 #define DTAU_IN(i) prop[(nlay - (i) - 1) * len1]
 #define W_IN(i) prop[(nlay - (i) - 1) * len1 + 1]
 #define G_IN(i) prop[(nlay - (i) - 1) * len1 + 2]
-#define FLX_UP(i) flx[2 * (nlev - (i) - 1)]
-#define FLX_DN(i) flx[2 * (nlev - (i) - 1) + 1]
+// 4 channels per level: [0]=level up, [1]=level down,
+// [2]=layer-midpoint up, [3]=layer-midpoint down. Shortwave is smooth and (in
+// the RCE solve) frozen, so it is not the source of the period-2 null mode;
+// the midpoint channels are set equal to the level channels (good to O(dtau))
+// at the end of this routine. Level channels [0,1] are unchanged.
+#define FLX_UP(i) flx[4 * (nlev - (i) - 1)]
+#define FLX_DN(i) flx[4 * (nlev - (i) - 1) + 1]
 #define MU_IN(i) mu_in[nlev - (i) - 1]
 
 namespace harp {
@@ -224,6 +229,15 @@ DISPATCH_MACRO void toon_mckay89_shortwave(int nlay, T F0_in, T const* mu_in,
     for (int k = 0; k < nlev; k++) {
       printf("Level %d: FLX_UP = %e, FLX_DN = %e\n", k, FLX_UP(k), FLX_DN(k));
     }*/
+  }
+
+  // Midpoint channels: shortwave is smooth (direct beam + slowly-varying
+  // diffuse), so set the layer-midpoint flux equal to the level flux at each
+  // slot (O(dtau) accurate). This keeps the combined LW+SW midpoint residual
+  // well defined without porting the shortwave source-function midpoint.
+  for (int j = 0; j < nlev; j++) {
+    flx[4 * j + 2] = flx[4 * j];
+    flx[4 * j + 3] = flx[4 * j + 1];
   }
 }
 

--- a/src/rtsolver/toon_mckay89_shortwave_impl.h
+++ b/src/rtsolver/toon_mckay89_shortwave_impl.h
@@ -231,13 +231,34 @@ DISPATCH_MACRO void toon_mckay89_shortwave(int nlay, T F0_in, T const* mu_in,
     }*/
   }
 
-  // Midpoint channels: shortwave is smooth (direct beam + slowly-varying
-  // diffuse), so set the layer-midpoint flux equal to the level flux at each
-  // slot (O(dtau) accurate). This keeps the combined LW+SW midpoint residual
-  // well defined without porting the shortwave source-function midpoint.
+  // Midpoint channels [2]=mid up, [3]=mid down. Start from the level value: the
+  // diffuse up/down are smooth (O(dtau) accurate at the midpoint).
   for (int j = 0; j < nlev; j++) {
     flx[4 * j + 2] = flx[4 * j];
     flx[4 * j + 3] = flx[4 * j + 1];
+  }
+  // Direct-beam midpoint correction. The direct beam is the dominant SW term
+  // (~60 Fint in an irradiated skin) and attenuates EXPONENTIALLY across a layer,
+  // so its value at the layer-k midpoint is sqrt(dir[k]*dir[k+1]) (geometric mean
+  // = exact for an exponential; holds for constant or slant-path mu). Replacing
+  // the level beam with the midpoint beam in FLX_DN_MID(k) makes the SW
+  // layer-midpoint net flux match PICASO's flux_net_v_layer to leading order.
+  // Without it the combined LW+SW midpoint residual is INCONSISTENT (true LW
+  // midpoint + level-approx SW) and the RCE Newton drifts off irradiated
+  // (inversion) fixed points. UP is unaffected (the beam is downward only).
+  // all_zero_w case: FLX_DN itself IS the beam. FLX_DN_MID(k)=flx[4*(nlev-k-1)+3].
+  for (int k = 0; k < nlay; k++) {
+    T dir_k, dir_kp1;
+    if (all_zero_w) {
+      dir_k = flx[4 * (nlev - k - 1) + 1];   // FLX_DN(k)   = pure beam
+      dir_kp1 = flx[4 * (nlev - k - 2) + 1]; // FLX_DN(k+1)
+    } else {
+      dir_k = dir[k];
+      dir_kp1 = dir[k + 1];
+    }
+    T dir_mid = sqrt(fmax(dir_k * dir_kp1, (T)0.0));
+    flx[4 * (nlev - k - 1) + 3] =
+        flx[4 * (nlev - k - 1) + 1] - dir_k + dir_mid;
   }
 }
 

--- a/src/rtsolver/toon_mckay89_shortwave_impl.h
+++ b/src/rtsolver/toon_mckay89_shortwave_impl.h
@@ -238,27 +238,27 @@ DISPATCH_MACRO void toon_mckay89_shortwave(int nlay, T F0_in, T const* mu_in,
     flx[4 * j + 3] = flx[4 * j + 1];
   }
   // Direct-beam midpoint correction. The direct beam is the dominant SW term
-  // (~60 Fint in an irradiated skin) and attenuates EXPONENTIALLY across a layer,
-  // so its value at the layer-k midpoint is sqrt(dir[k]*dir[k+1]) (geometric mean
-  // = exact for an exponential; holds for constant or slant-path mu). Replacing
-  // the level beam with the midpoint beam in FLX_DN_MID(k) makes the SW
-  // layer-midpoint net flux match PICASO's flux_net_v_layer to leading order.
-  // Without it the combined LW+SW midpoint residual is INCONSISTENT (true LW
-  // midpoint + level-approx SW) and the RCE Newton drifts off irradiated
-  // (inversion) fixed points. UP is unaffected (the beam is downward only).
-  // all_zero_w case: FLX_DN itself IS the beam. FLX_DN_MID(k)=flx[4*(nlev-k-1)+3].
+  // (~60 Fint in an irradiated skin) and attenuates EXPONENTIALLY across a
+  // layer, so its value at the layer-k midpoint is sqrt(dir[k]*dir[k+1])
+  // (geometric mean = exact for an exponential; holds for constant or
+  // slant-path mu). Replacing the level beam with the midpoint beam in
+  // FLX_DN_MID(k) makes the SW layer-midpoint net flux match PICASO's
+  // flux_net_v_layer to leading order. Without it the combined LW+SW midpoint
+  // residual is INCONSISTENT (true LW midpoint + level-approx SW) and the RCE
+  // Newton drifts off irradiated (inversion) fixed points. UP is unaffected
+  // (the beam is downward only). all_zero_w case: FLX_DN itself IS the beam.
+  // FLX_DN_MID(k)=flx[4*(nlev-k-1)+3].
   for (int k = 0; k < nlay; k++) {
     T dir_k, dir_kp1;
     if (all_zero_w) {
-      dir_k = flx[4 * (nlev - k - 1) + 1];   // FLX_DN(k)   = pure beam
-      dir_kp1 = flx[4 * (nlev - k - 2) + 1]; // FLX_DN(k+1)
+      dir_k = flx[4 * (nlev - k - 1) + 1];    // FLX_DN(k)   = pure beam
+      dir_kp1 = flx[4 * (nlev - k - 2) + 1];  // FLX_DN(k+1)
     } else {
       dir_k = dir[k];
       dir_kp1 = dir[k + 1];
     }
     T dir_mid = sqrt(fmax(dir_k * dir_kp1, (T)0.0));
-    flx[4 * (nlev - k - 1) + 3] =
-        flx[4 * (nlev - k - 1) + 1] - dir_k + dir_mid;
+    flx[4 * (nlev - k - 1) + 3] = flx[4 * (nlev - k - 1) + 1] - dir_k + dir_mid;
   }
 }
 

--- a/tests/test_flux_utils.cpp
+++ b/tests/test_flux_utils.cpp
@@ -59,7 +59,7 @@ TEST(FluxUtilsTest, CalNetFlux) {
 
 TEST(FluxUtilsTest, CalNetFluxInvalidInput) {
   // Create a 2D tensor with random values
-  torch::Tensor flux = torch::rand({5, 3});
+  torch::Tensor flux = torch::rand({5, 1});
 
   // Check for invalid input
   EXPECT_THROW(harp::cal_net_flux(flux), c10::Error);
@@ -80,7 +80,7 @@ TEST(FluxUtilsTest, CalSurfaceFlux) {
 
 TEST(FluxUtilsTest, CalSurfaceFluxInvalidInput) {
   // Create a 2D tensor with random values
-  torch::Tensor flux = torch::rand({5, 3});
+  torch::Tensor flux = torch::rand({5, 1});
 
   // Check for invalid input
   EXPECT_THROW(harp::cal_surface_flux(flux), c10::Error);
@@ -101,7 +101,7 @@ TEST(FluxUtilsTest, CalTOAFlux) {
 
 TEST(FluxUtilsTest, CalTOAFluxInvalidInput) {
   // Create a 2D tensor with random values
-  torch::Tensor flux = torch::rand({5, 3});
+  torch::Tensor flux = torch::rand({5, 1});
 
   // Check for invalid input
   EXPECT_THROW(harp::cal_toa_flux(flux), c10::Error);

--- a/tests/test_toon.cpp
+++ b/tests/test_toon.cpp
@@ -140,6 +140,58 @@ TEST_P(DeviceTest, simple_toon_mckay89) {
   }
 }
 
+// Regression: for a Lambertian surface the reflected upward flux must equal
+// albedo * (total downward flux at the surface), where the total includes both
+// the diffuse and the direct beam.  Output level index 0 is the surface.  This
+// guards the shortwave bottom boundary condition, including the zero-single-
+// scattering-albedo case, which must NOT take the direct-beam-only shortcut
+// when the surface albedo is nonzero.
+TEST_P(DeviceTest, shortwave_surface_albedo_reflection) {
+  auto op = harp::ToonMcKay89OptionsImpl::create();
+  op->wave_lower({200., 500., 1000.});
+  op->wave_upper({500., 1000., 2000.});
+
+  harp::ToonMcKay89 toon(op);
+  toon->to(device, dtype);
+
+  int nwave = op->wave_lower().size();
+  int nlyr = 20;
+  int ncol = 2;
+  int nprop = 3;
+
+  double total_tau = 1.0;
+  double fbeam = 100.0;
+  double umu0 = 0.5;
+  double albedo = 0.1;
+
+  auto prop = torch::zeros({nwave, ncol, nlyr, nprop},
+                           torch::device(device).dtype(dtype));
+  prop.select(-1, 0) = total_tau / nlyr;  // uniform dtau per layer
+
+  std::map<std::string, torch::Tensor> bc;
+  bc["fbeam"] = torch::ones({nwave, ncol}, prop.options()) * fbeam;
+  bc["umu0"] = torch::ones({ncol}, prop.options()) * umu0;
+  bc["albedo"] = torch::ones({nwave, ncol}, prop.options()) * albedo;
+
+  double tol = (dtype == torch::kFloat64) ? 1e-11 : 1e-3;
+
+  // ssa = 0 (pure absorption, exercises the shortcut guard), a tiny nonzero
+  // ssa, and a genuinely scattering case handled by the general solver.
+  for (auto [w0, g] : {std::make_pair(0.0, 0.0), std::make_pair(1.0e-10, 0.0),
+                       std::make_pair(0.5, 0.5)}) {
+    prop.select(-1, 1) = w0;  // single scattering albedo
+    prop.select(-1, 2) = g;   // asymmetry parameter
+
+    auto flx = toon(prop, &bc);
+    auto up_surf = flx.select(-1, 0).select(-1, 0);  // up flux at the surface
+    auto dn_surf = flx.select(-1, 1).select(-1, 0);  // down flux at the surface
+
+    auto resid = (up_surf - albedo * dn_surf).abs().max().item<double>();
+    EXPECT_LT(resid, tol) << "surface reflection failed for w0=" << w0
+                          << " g=" << g << " resid=" << resid;
+  }
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
Two additive features for the ToonMcKay89 solver. **Existing behavior is unchanged** — the level up/down fluxes are bit-identical and `forward()` keeps its current return signature, so DISORT and any current caller are unaffected.

- **Layer-midpoint flux output**: the Toon flux tensor is widened from 2 to 4 channels, and the two new channels carry the flux evaluated at the half-layer optical depth, matching PICASO's `flux_*_mdpt` grid-output convention. The longwave value comes from the source-function solution at the midpoint; the shortwave value uses the geometric mean of the direct beam across the layer (exact for exponential attenuation). This is exposed via a new `Radiation::net_flux_midpt` buffer. Bands whose solver only produces level fluxes (e.g. DISORT) are padded so the midpoint channel falls back to the level value.
- **Configurable top-emission factor**: `btop_factor` sets the auto `tau_top = dtau[0] * btop_factor` used when `top_emission_flag < 0`. It defaults to `exp(-1)` (the previous hard-coded value, so nothing changes by default); setting it to `plevel[0]/(plevel[1]-plevel[0])` reproduces PICASO's top boundary convention.

Also adds a shortwave regression test asserting the Lambertian surface condition `F_up(surface) = albedo * F_down(surface)` (diffuse + direct beam) across zero, near-zero, and scattering single-scattering albedo.

Validated against PICASO `get_thermal_1d` (2.2%) and pyharp's DISORT solver (0.04%).
