### PR TITLE
Fix out-of-bounds molecular opacity interpolation

### DIFF
--- a/src/opacity/molecule_cia.cpp
+++ b/src/opacity/molecule_cia.cpp
@@ -139,9 +139,11 @@ torch::Tensor MoleculeCIAImpl::forward(
   auto lnp_grid = lnp.unsqueeze(0).expand({nwave, ncol, nlyr});
   auto temp_grid = del_temp.unsqueeze(0).expand({nwave, ncol, nlyr});
 
+  // Clamp queries to the tabulated bounds. Extrapolating logarithmic CIA
+  // coefficients can produce nonphysical opacity outside the table coverage.
   auto coeff = interpn({wave, lnp_grid, temp_grid},
                        {wavenumber, ln_pressure, temperature_anomaly},
-                       ln_sigma_binary, true)
+                       ln_sigma_binary, false)
                    .exp();
 
   auto species0 = conc.select(-1, options->species_ids().at(0));

--- a/src/opacity/molecule_line.cpp
+++ b/src/opacity/molecule_line.cpp
@@ -150,9 +150,11 @@ torch::Tensor MoleculeLineImpl::forward(
   lnp = lnp.unsqueeze(0).expand({nwave, ncol, nlyr});
   tempa = tempa.unsqueeze(0).expand({nwave, ncol, nlyr});
 
+  // Clamp queries to the tabulated bounds. Extrapolating logarithmic line
+  // cross sections can produce nonphysical opacity outside the table coverage.
   auto out = interpn({wave, lnp, tempa},
                      {wavenumber, ln_pressure, temperature_anomaly},
-                     ln_sigma_cross, true)
+                     ln_sigma_cross, false)
                  .exp();
 
   // Check species id in range

--- a/src/utils/netcdf_opacity_utils.hpp
+++ b/src/utils/netcdf_opacity_utils.hpp
@@ -225,10 +225,10 @@ inline torch::Tensor convert_temperature_to_k(torch::Tensor values,
 inline torch::Tensor apply_positive_fill(torch::Tensor values,
                                          std::string const& quantity_name) {
   auto const positive_mask = values > 0;
-  double fill_value = 1.0e-300;
-  if (positive_mask.any().item<bool>()) {
-    fill_value = values.masked_select(positive_mask).min().item<double>();
-  }
+  // Use a fixed negligible floor only to keep log-space interpolation finite.
+  // Filling zeros with the table's smallest positive value would create an
+  // artificial opacity floor outside the source's spectral coverage.
+  double const fill_value = 1.0e-300;
 
   TORCH_CHECK(std::isfinite(fill_value) && fill_value > 0.0,
               "Invalid positive fill value for ", quantity_name, ": ",

--- a/tests/test_attenuator.cpp
+++ b/tests/test_attenuator.cpp
@@ -176,6 +176,52 @@ TEST(TestOpacity, CIAHandlesBinaryPairsAndReversedSpeciesOrder) {
 #endif
 }
 
+TEST(TestOpacity, MoleculeOpacitiesClampTemperatureAnomalyToTableBounds) {
+#ifndef NETCDFOUTPUT
+  GTEST_SKIP() << "NetCDF support is disabled";
+#else
+  auto dataset = write_test_dataset();
+  harp::species_names = {"H2O", "H2", "He"};
+  harp::species_weights = {18.0e-3, 2.0e-3, 4.0e-3};
+
+  auto line_options = harp::OpacityOptionsImpl::create();
+  line_options->type("molecule-line")
+      .species_ids({0})
+      .opacity_files({dataset.string()});
+  harp::MoleculeLine line(line_options);
+
+  auto cia_options = harp::OpacityOptionsImpl::create();
+  cia_options->type("molecule-cia")
+      .species_ids({1, 2})
+      .opacity_files({dataset.string()});
+  harp::MoleculeCIA cia(cia_options);
+
+  auto conc = torch::ones({1, 1, 3}, torch::kFloat64);
+  std::map<std::string, torch::Tensor> atm;
+  atm["pres"] = torch::tensor({{1.0e5}}, torch::kFloat64);
+  atm["wavenumber"] = torch::tensor({20.0, 21.0, 22.0}, torch::kFloat64);
+
+  auto evaluate = [&](auto& opacity, double temperature) {
+    atm["temp"] = torch::tensor({{temperature}}, torch::kFloat64);
+    return opacity->forward(conc, atm);
+  };
+
+  auto line_lower_bound = evaluate(line, 290.0);
+  auto line_below_bound = evaluate(line, 270.0);
+  auto line_upper_bound = evaluate(line, 310.0);
+  auto line_above_bound = evaluate(line, 330.0);
+  EXPECT_TRUE(torch::allclose(line_below_bound, line_lower_bound));
+  EXPECT_TRUE(torch::allclose(line_above_bound, line_upper_bound));
+
+  auto cia_lower_bound = evaluate(cia, 290.0);
+  auto cia_below_bound = evaluate(cia, 270.0);
+  auto cia_upper_bound = evaluate(cia, 310.0);
+  auto cia_above_bound = evaluate(cia, 330.0);
+  EXPECT_TRUE(torch::allclose(cia_below_bound, cia_lower_bound));
+  EXPECT_TRUE(torch::allclose(cia_above_bound, cia_upper_bound));
+#endif
+}
+
 TEST(TestOpacity, NewOpacityTypesParseFromYaml) {
   harp::species_names = {"H2O", "H2", "He"};
   harp::species_weights = {18.0e-3, 2.0e-3, 4.0e-3};

--- a/tests/test_attenuator.cpp
+++ b/tests/test_attenuator.cpp
@@ -138,10 +138,11 @@ TEST(TestOpacity, MoleculeLineAddsContinuumAndHandlesDimensionOrder) {
 
   auto result = line->forward(conc, atm).squeeze(-1).squeeze(-1).squeeze(-1);
   auto expected_sigma =
-      torch::tensor({3.1e-24, 3.1e-24, 5.1e-24}, torch::kFloat64) *
+      torch::tensor({0.0, 3.1e-24, 5.1e-24}, torch::kFloat64) *
       (1.0e-4 * harp::constants::Avogadro);
   auto expected = expected_sigma * 2.0;
   EXPECT_TRUE(torch::allclose(result, expected, 1.0e-12, 1.0e-12));
+  EXPECT_LT(result[0].item<double>(), 1.0e-250);
 #endif
 }
 
@@ -169,10 +170,11 @@ TEST(TestOpacity, CIAHandlesBinaryPairsAndReversedSpeciesOrder) {
 
   auto result = cia->forward(conc, atm).squeeze(-1).squeeze(-1).squeeze(-1);
   auto expected_coeff =
-      torch::tensor({3.0e-46, 3.0e-46, 4.0e-46}, torch::kFloat64) *
+      torch::tensor({0.0, 3.0e-46, 4.0e-46}, torch::kFloat64) *
       (1.0e-10 * harp::constants::Avogadro * harp::constants::Avogadro);
   auto expected = expected_coeff * 12.0;
   EXPECT_TRUE(torch::allclose(result, expected, 1.0e-12, 1.0e-12));
+  EXPECT_LT(result[0].item<double>(), 1.0e-250);
 #endif
 }
 


### PR DESCRIPTION
## Summary

This PR fixes two boundary-handling issues in the NetCDF-backed molecular opacity readers.

- Clamp out-of-range wavenumber, pressure, and temperature-anomaly queries to the tabulated bounds for both molecular line and CIA opacity.
- Replace zero opacity values with a fixed negligible numerical floor (`1e-300`) before log-space interpolation, instead of using the table's minimum positive value.

## Motivation

`MoleculeLine` and `MoleculeCIA` previously called `interpn(..., true)`. Due to the current interpolation index handling, queries below the lower table boundary were extrapolated in log space, while queries above the upper boundary were clamped. This produced asymmetric and potentially nonphysical opacity behavior.

In addition, `apply_positive_fill()` replaced zero-valued cells with the smallest positive value found anywhere in the table. For sparsely covered CIA datasets, this could introduce an artificial broadband opacity floor outside the source's spectral coverage.

## Changes

- Set `extrapolate=false` in `MoleculeLineImpl::forward()`.
- Set `extrapolate=false` in `MoleculeCIAImpl::forward()`.
- Use a fixed `1e-300` floor solely to keep `log()` finite.
- Update zero-opacity expectations in the existing tests.
- Add regression coverage for temperature queries below and above the tabulated anomaly range.

## Testing

Built and ran the targeted C++ test:

```text
test_attenuator.release: Passed
100% tests passed, 0 tests failed