### PR TITLE
Align HITRAN downloads with 25 cm-1 line wings

### DIFF
--- a/python/spectra/hitran_molecule_utils.py
+++ b/python/spectra/hitran_molecule_utils.py
@@ -19,6 +19,9 @@ from .hitran_cia_utils import load_cia_dataset
 from .utils import build_band_from_range
 
 
+LINE_WING_CM1 = 25.0
+
+
 def _import_hapi():
     try:
         return importlib.import_module("hapi")
@@ -116,7 +119,7 @@ class HapiLineProvider:
             GammaD,
             Gamma0,
             Delta0,
-            np.asarray([shifted_center + 25.0]),
+            np.asarray([shifted_center + LINE_WING_CM1]),
             YRosen=YRosen,
             Sw=Sw,
         )[0]
@@ -125,11 +128,11 @@ class HapiLineProvider:
     def _voigt_kwargs(self) -> dict[str, object]:
         if not self._is_h2o:
             return {
-                "WavenumberWing": 25.0,
-                "WavenumberWingHW": 50.0,
+                "WavenumberWing": LINE_WING_CM1,
+                "WavenumberWingHW": 0.0,
             }
         return {
-            "WavenumberWing": 25.0,
+            "WavenumberWing": LINE_WING_CM1,
             "WavenumberWingHW": 0.0,
             "profile": self._h2o_voigt_minus_pedestal,
             "calcpars": self._hapi.calculateProfileParametersVoigt,
@@ -275,13 +278,24 @@ def _format_diluent(diluent: dict[str, float]) -> str:
     return ",".join(f"{name}:{value:.3f}" for name, value in sorted(diluent.items()))
 
 
+def _line_source_band(band: SpectralBandConfig) -> SpectralBandConfig:
+    """Return the line-center range needed to cover the output-band wings."""
+    return SpectralBandConfig(
+        name=f"{band.name}_line_source",
+        wavenumber_min_cm1=max(0.0, band.wavenumber_min_cm1 - LINE_WING_CM1),
+        wavenumber_max_cm1=band.wavenumber_max_cm1 + LINE_WING_CM1,
+        resolution_cm1=band.resolution_cm1,
+    )
+
+
 def download_hitran_lines(config: SpectroscopyConfig, band: SpectralBandConfig) -> LineDatabase:
-    """Fetch the configured species line table for one spectral band."""
+    """Fetch line centers over the output band plus the fixed line wings."""
     config.ensure_directories()
     hapi = _import_hapi()
-    bounds_min = band.wavenumber_min_cm1
-    bounds_max = band.wavenumber_max_cm1
-    table_name = config.resolved_line_table_name(band)
+    line_band = _line_source_band(band)
+    bounds_min = line_band.wavenumber_min_cm1
+    bounds_max = line_band.wavenumber_max_cm1
+    table_name = config.resolved_line_table_name(line_band)
     global_iso_ids = _resolve_global_isotopologue_ids(hapi, config)
     _call_hapi_quietly(hapi.db_begin, str(config.hitran_cache_dir))
     data_path = config.hitran_cache_dir / f"{table_name}.data"

--- a/tests/spectra/test_hitran_lines.py
+++ b/tests/spectra/test_hitran_lines.py
@@ -43,22 +43,33 @@ class FakeHapi:
         return grid, np.ones_like(grid)
 
 
-def test_download_hitran_lines_uses_band_bounds(monkeypatch, tmp_path) -> None:
+def _line_source_band(band: SpectralBandConfig) -> SpectralBandConfig:
+    return SpectralBandConfig(
+        band.name,
+        max(0.0, band.wavenumber_min_cm1 - 25.0),
+        band.wavenumber_max_cm1 + 25.0,
+        band.resolution_cm1,
+    )
+
+
+def test_download_hitran_lines_pads_band_by_line_wing(monkeypatch, tmp_path) -> None:
     fake = FakeHapi()
     monkeypatch.setattr("pyharp.spectra.hitran_molecule_utils._import_hapi", lambda: fake)
     config = SpectroscopyConfig(output_path=tmp_path / "out.nc", hitran_cache_dir=tmp_path / "cache")
     band = SpectralBandConfig("single_state", 25.0, 2500.0, 1.0)
+    line_band = _line_source_band(band)
+    table_name = config.resolved_line_table_name(line_band)
 
     db = download_hitran_lines(config, band)
 
-    assert db.table_name == config.resolved_line_table_name(band)
+    assert db.table_name == table_name
     assert fake.db_dir == str(config.hitran_cache_dir)
     assert fake.calls == [
         (
-            config.resolved_line_table_name(band),
+            table_name,
             (7, 8, 9, 10, 11, 12, 13),
-            band.wavenumber_min_cm1,
-            band.wavenumber_max_cm1,
+            line_band.wavenumber_min_cm1,
+            line_band.wavenumber_max_cm1,
         )
     ]
 
@@ -69,7 +80,7 @@ def test_download_hitran_lines_skips_fetch_when_cache_exists(monkeypatch, tmp_pa
     config = SpectroscopyConfig(output_path=tmp_path / "out.nc", hitran_cache_dir=tmp_path / "cache")
     band = SpectralBandConfig("single_state", 25.0, 2500.0, 1.0)
     config.hitran_cache_dir.mkdir(parents=True, exist_ok=True)
-    table_name = config.resolved_line_table_name(band)
+    table_name = config.resolved_line_table_name(_line_source_band(band))
     (config.hitran_cache_dir / f"{table_name}.data").write_text("x", encoding="utf-8")
     (config.hitran_cache_dir / f"{table_name}.header").write_text("x", encoding="utf-8")
     fake.LOCAL_TABLE_CACHE[table_name] = {"data": {"molec_id": [2, 2, 2]}}
@@ -85,8 +96,9 @@ def test_download_hitran_lines_refetches_contaminated_cache(monkeypatch, tmp_pat
     monkeypatch.setattr("pyharp.spectra.hitran_molecule_utils._import_hapi", lambda: fake)
     config = SpectroscopyConfig(output_path=tmp_path / "out.nc", hitran_cache_dir=tmp_path / "cache")
     band = SpectralBandConfig("single_state", 25.0, 2500.0, 1.0)
+    line_band = _line_source_band(band)
     config.hitran_cache_dir.mkdir(parents=True, exist_ok=True)
-    table_name = config.resolved_line_table_name(band)
+    table_name = config.resolved_line_table_name(line_band)
     (config.hitran_cache_dir / f"{table_name}.data").write_text("x", encoding="utf-8")
     (config.hitran_cache_dir / f"{table_name}.header").write_text("x", encoding="utf-8")
     fake.LOCAL_TABLE_CACHE[table_name] = {"data": {"molec_id": [1, 2]}}
@@ -98,8 +110,8 @@ def test_download_hitran_lines_refetches_contaminated_cache(monkeypatch, tmp_pat
         (
             table_name,
             (7, 8, 9, 10, 11, 12, 13),
-            band.wavenumber_min_cm1,
-            band.wavenumber_max_cm1,
+            line_band.wavenumber_min_cm1,
+            line_band.wavenumber_max_cm1,
         )
     ]
 
@@ -114,12 +126,14 @@ def test_download_hitran_lines_wraps_fetch_failures(monkeypatch, tmp_path) -> No
     fake.fetch_by_ids = fail_fetch
     config = SpectroscopyConfig(output_path=tmp_path / "out.nc", hitran_cache_dir=tmp_path / "cache", species_name="CO2")
     band = SpectralBandConfig("single_state", 2500.0, 10000.0, 1.0)
+    line_band = _line_source_band(band)
 
     try:
         download_hitran_lines(config, band)
     except RuntimeError as exc:
         assert "Failed to download HITRAN lines for CO2" in str(exc)
-        assert "2500-10000 cm^-1" in str(exc)
+        expected_range = f"{line_band.wavenumber_min_cm1:g}-{line_band.wavenumber_max_cm1:g} cm^-1"
+        assert expected_range in str(exc)
     else:
         raise AssertionError("expected RuntimeError")
 
@@ -158,6 +172,7 @@ def test_hapi_line_provider_passes_min_line_strength_to_hapi(monkeypatch, tmp_pa
 
     assert fake.absorption_calls[-1]["IntensityThreshold"] == 1.0e-27
     assert fake.absorption_calls[-1]["HITRAN_units"] is True
+    assert fake.absorption_calls[-1]["WavenumberWingHW"] == 0.0
 
 
 def test_hapi_line_provider_falls_back_missing_broadener_to_air(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
fix: align HITRAN downloads with 25 cm-1 line wings

- extend HITRAN line download bounds by 25 cm-1
- clamp the lower bound at 0 cm-1
- set WavenumberWingHW to 0 for a fixed 25 cm-1 cutoff
- keep the requested output spectral grid unchanged

Very niche update; can hold for a future PyPI release. This follows the LBLRTM ILBLF4=1 convention by applying a fixed ±25 cm⁻¹ line-wing cutoff and padding the HITRAN download range accordingly.