### PR TITLE
Fix hard_surface ignored in Toon89 CPU longwave dispatch

### DIFF
--- a/src/rtsolver/rtsolver_dispatch.cpp
+++ b/src/rtsolver/rtsolver_dispatch.cpp
@@ -58,12 +58,6 @@ void call_toon89_lw_cpu(at::TensorIterator& iter, bool /*zenith_correction*/,
             auto prop = reinterpret_cast<scalar_t*>(data[1] + i * strides[1]);
             auto be = reinterpret_cast<scalar_t*>(data[2] + i * strides[2]);
             auto albedo = reinterpret_cast<scalar_t*>(data[3] + i * strides[3]);
-            auto hard_surface =
-                reinterpret_cast<scalar_t*>(data[4] + i * strides[4]);
-            auto top_emission =
-                reinterpret_cast<scalar_t*>(data[5] + i * strides[5]);
-            auto delta_edd_lw =
-                reinterpret_cast<scalar_t*>(data[6] + i * strides[6]);
             toon_mckay89_longwave(nlay, be, prop, *albedo, top_emission_flag,
                                   static_cast<scalar_t>(btop_factor),
                                   hard_surface, delta_eddington_lw, out, len1,


### PR DESCRIPTION
`call_toon89_lw_cpu` read three unused per-cell locals from `data[4..6]`, past the end of the 4-operand iterator. The `hard_surface` one shadowed the scalar `bool` argument, so the CPU longwave solver always ran the terrestrial surface branch regardless of the flag. The CUDA dispatch was unaffected.

Removing the dead reads makes the scalar arguments bind, matching `call_toon89_lw_cuda`.

Verified on a 1-layer thermal column (CPU): before, `hard_surface` on/off give an identical base flux (diff 0.0); after, they differ (125000.84 vs 3010.16), matching the GPU result to float precision.
