### PR TITLE
Add ReSPQ opacity table support

### DIFF
--- a/docs/source/opacity.rst
+++ b/docs/source/opacity.rst
@@ -32,6 +32,9 @@ A complete list of built-in opacity types is given in the table below.
   * - 'rayleigh'
     - Analytic
     - Gas Rayleigh scattering for H2, He, H2O, CH4, N2, and CO2 on the active spectral grid
+  * - 'respq-table'
+    - NetCDF
+    - Frozen ReSPQ quadrature and component optical-property tables
   * - 'multiband-ck'
     - '.pt' (saved by :func:`torch.jit.save`)
     - Three-dimensional correlated-k opacity lookup table. The axis are
@@ -82,6 +85,11 @@ line-by-line grid. It does not need to be stored in the absorption NetCDF file:
 ``nmom`` should be at least 2 and normally matches ``nstr``. The opacity
 returns conservative scattering and the Rayleigh Legendre moments; the
 radiation band combines it with molecular absorption before calling DISORT.
+
+A ``respq-table`` must be the only opacity source in its band. The NetCDF file
+provides the spectral points, bounds, weights, pressure-temperature grid,
+reference composition, and optional scattering properties. Lookup is clamped
+to the table bounds and recorded in the module's ``bounds_mask`` buffer.
 
 .. _example_sonora:
 

--- a/python/opacity.pyi
+++ b/python/opacity.pyi
@@ -61,7 +61,7 @@ class OpacityOptions:
 
         Valid options are: ``jit``, ``molecule-line``, ``molecule-cia``,
         ``fourcolumn``, ``wavetemp``, ``multiband-ck``, ``picaso-ck``,
-        ``rayleigh``, ``helios``.
+        ``rayleigh``, ``respq-table``, ``helios``.
 
         Args:
             value (str): type of the opacity source

--- a/src/opacity/respq_table.cpp
+++ b/src/opacity/respq_table.cpp
@@ -1,0 +1,247 @@
+#include "respq_table.hpp"
+
+#include <harp/math/interpolation.hpp>
+#include <harp/utils/netcdf_opacity_utils.hpp>
+
+namespace harp {
+
+namespace {
+#ifdef NETCDFOUTPUT
+torch::Tensor read_components(int fileid, std::string const& name,
+                              std::string const& component_dim,
+                              std::string const& expected_units) {
+  int varid = -1;
+  check_nc(nc_inq_varid(fileid, name.c_str(), &varid),
+           "Missing required variable " + name);
+  auto const units = normalize_token(read_var_units(fileid, varid));
+  TORCH_CHECK(units == normalize_token(expected_units), name,
+              " units must be '", expected_units, "'");
+  return read_tensor_permuted(
+             fileid, name,
+             {"pressure", "temperature_offset", "point", component_dim})
+      .clamp_min(1.e-300)
+      .log();
+}
+#endif
+}  // namespace
+
+RespqTableImpl::RespqTableImpl(OpacityOptions const& options_)
+    : options(options_) {
+  TORCH_CHECK(options->opacity_files().size() == 1,
+              "Only one opacity file is allowed");
+  TORCH_CHECK(options->type().empty() || options->type() == "respq-table",
+              "Mismatch opacity type: ", options->type(),
+              " expecting 'respq-table'");
+  reset();
+}
+
+void RespqTableImpl::reset() {
+#ifdef NETCDFOUTPUT
+  int fileid = open_file(options->opacity_files()[0]);
+
+  wavenumber = read_1d_variable(fileid, "wavenumber");
+  wave_lower = read_1d_variable(fileid, "wavenumber_lower");
+  wave_upper = read_1d_variable(fileid, "wavenumber_upper");
+  weights =
+      read_1d_variable(fileid, "quadrature_weight") / (wave_upper - wave_lower);
+
+  ln_pressure = read_1d_variable(fileid, "pressure").log();
+  temperature_anomaly = read_1d_variable(fileid, "temperature_offset");
+  ln_temperature_base =
+      read_1d_variable(fileid, "nominal_temperature").log().unsqueeze(-1);
+  reference_mole_fraction = read_1d_variable(fileid, "reference_mole_fraction");
+
+  int varid = -1;
+  if (try_find_varid(fileid, "kappa_linear", &varid)) {
+    ln_linear =
+        read_components(fileid, "kappa_linear", "linear_component", "m2 mol-1");
+    nlinear = ln_linear.size(-1);
+    ln_linear = ln_linear.reshape(
+        {ln_pressure.numel(), temperature_anomaly.numel(), -1});
+  }
+  if (try_find_varid(fileid, "kappa_binary", &varid)) {
+    ln_binary =
+        read_components(fileid, "kappa_binary", "binary_component", "m5 mol-2");
+    nbinary = ln_binary.size(-1);
+    ln_binary = ln_binary.reshape(
+        {ln_pressure.numel(), temperature_anomaly.numel(), -1});
+  }
+  if (try_find_varid(fileid, "scattering_coefficient", &varid)) {
+    TORCH_CHECK(normalize_token(read_var_units(fileid, varid)) == "m2_mol_1",
+                "scattering_coefficient units must be 'm2 mol-1'");
+    scattering = read_1d_variable(fileid, "scattering_coefficient");
+    phase_moment =
+        read_tensor_permuted(fileid, "phase_moment", {"point", "moment"});
+  }
+
+  check_nc(nc_close(fileid), "Failed to close NetCDF file");
+#else
+  TORCH_CHECK(false, "NetCDF support is not enabled");
+#endif
+
+  int64_t const npoint = wavenumber.numel();
+  TORCH_CHECK(npoint > 0, "ReSPQ table is empty");
+  TORCH_CHECK(wave_lower.numel() == npoint && wave_upper.numel() == npoint &&
+                  weights.numel() == npoint,
+              "ReSPQ spectral arrays must have the same length");
+  TORCH_CHECK(torch::all(wave_upper > wave_lower).item<bool>(),
+              "ReSPQ points must have positive spectral widths");
+  TORCH_CHECK(
+      torch::all(torch::isfinite(weights) & (weights >= 0.)).item<bool>(),
+      "ReSPQ weights must be finite and non-negative");
+  if (npoint > 1) {
+    TORCH_CHECK(torch::all(wavenumber.slice(0, 1, npoint) >
+                           wavenumber.slice(0, 0, npoint - 1))
+                    .item<bool>(),
+                "ReSPQ wavenumbers must be strictly increasing");
+  }
+  TORCH_CHECK(ln_pressure.numel() > 1 &&
+                  torch::all(ln_pressure.slice(0, 1, ln_pressure.numel()) >
+                             ln_pressure.slice(0, 0, ln_pressure.numel() - 1))
+                      .item<bool>(),
+              "ReSPQ pressure must be strictly increasing");
+  TORCH_CHECK(
+      temperature_anomaly.numel() > 1 &&
+          torch::all(
+              temperature_anomaly.slice(0, 1, temperature_anomaly.numel()) >
+              temperature_anomaly.slice(0, 0, temperature_anomaly.numel() - 1))
+              .item<bool>(),
+      "ReSPQ temperature_offset must be strictly increasing");
+  TORCH_CHECK(ln_linear.defined() || ln_binary.defined(),
+              "ReSPQ table has no absorption coefficients");
+  if (ln_linear.defined()) {
+    TORCH_CHECK(ln_linear.size(2) == npoint * nlinear,
+                "Invalid kappa_linear shape");
+  }
+  if (ln_binary.defined()) {
+    TORCH_CHECK(ln_binary.size(2) == npoint * nbinary,
+                "Invalid kappa_binary shape");
+  }
+  TORCH_CHECK(options->species_ids().size() ==
+                  static_cast<size_t>(reference_mole_fraction.numel()),
+              "ReSPQ species and reference composition sizes differ");
+  TORCH_CHECK(
+      torch::all(reference_mole_fraction >= 0.).item<bool>() &&
+          torch::isclose(reference_mole_fraction.sum(),
+                         torch::tensor(1., torch::kFloat64), 1.e-8, 1.e-8)
+              .item<bool>(),
+      "reference_mole_fraction must be non-negative and sum to one");
+  if (scattering.defined()) {
+    TORCH_CHECK(scattering.dim() == 1 && scattering.numel() == npoint &&
+                    torch::all(scattering >= 0.).item<bool>(),
+                "Invalid scattering_coefficient");
+    TORCH_CHECK(phase_moment.dim() == 2 && phase_moment.size(0) == npoint,
+                "phase_moment must have dimensions (point, moment)");
+  }
+
+  register_buffer("wavenumber", wavenumber);
+  register_buffer("weights", weights);
+  register_buffer("wave_lower", wave_lower);
+  register_buffer("wave_upper", wave_upper);
+  register_buffer("ln_pressure", ln_pressure);
+  register_buffer("temperature_anomaly", temperature_anomaly);
+  register_buffer("ln_temperature_base", ln_temperature_base);
+  if (ln_linear.defined()) register_buffer("ln_linear", ln_linear);
+  if (ln_binary.defined()) register_buffer("ln_binary", ln_binary);
+  if (scattering.defined()) {
+    register_buffer("scattering", scattering);
+    register_buffer("phase_moment", phase_moment);
+  }
+  register_buffer("reference_mole_fraction", reference_mole_fraction);
+  bounds_mask = register_buffer("bounds_mask", torch::zeros({0}, torch::kBool));
+}
+
+int RespqTableImpl::scattering_moments() const {
+  return phase_moment.defined() ? phase_moment.size(1) : 0;
+}
+
+torch::Tensor RespqTableImpl::forward(
+    torch::Tensor conc, std::map<std::string, torch::Tensor> const& kwargs) {
+  int ncol = conc.size(0);
+  int nlyr = conc.size(1);
+
+  TORCH_CHECK(kwargs.count("pres") > 0, "pres is required in kwargs");
+  TORCH_CHECK(kwargs.count("temp") > 0, "temp is required in kwargs");
+  auto const& pres = kwargs.at("pres");
+  auto const& temp = kwargs.at("temp");
+
+  TORCH_CHECK(pres.size(0) == ncol && pres.size(1) == nlyr,
+              "Invalid pres shape: ", pres.sizes(),
+              "; needs to be (ncol, nlyr)");
+  TORCH_CHECK(temp.size(0) == ncol && temp.size(1) == nlyr,
+              "Invalid temp shape: ", temp.sizes(),
+              "; needs to be (ncol, nlyr)");
+
+  if (kwargs.count("wavenumber") > 0) {
+    auto const& wave_query = kwargs.at("wavenumber");
+    TORCH_CHECK(wave_query.sizes() == wavenumber.sizes() &&
+                    torch::allclose(wave_query, wavenumber),
+                "RespqTable uses its frozen spectral points");
+  }
+
+  auto ids = torch::tensor(
+      options->species_ids(),
+      torch::TensorOptions().dtype(torch::kLong).device(conc.device()));
+  auto selected = conc.index_select(-1, ids);
+  auto total = selected.sum(-1);
+  TORCH_CHECK(torch::allclose(total, conc.sum(-1), 1.e-8, 1.e-12),
+              "ReSPQ species must cover the atmospheric composition");
+  TORCH_CHECK(torch::all(total > 0.).item<bool>(),
+              "ReSPQ composition must have positive total concentration");
+  auto fraction = selected / total.unsqueeze(-1);
+  auto reference = reference_mole_fraction.to(conc.options())
+                       .view({1, 1, -1})
+                       .expand_as(fraction);
+  TORCH_CHECK(torch::allclose(fraction, reference, 1.e-6, 1.e-8),
+              "Atmospheric composition does not match the ReSPQ table");
+
+  auto lnp = pres.log();
+  auto temperature_base =
+      interpn({lnp}, {ln_pressure}, ln_temperature_base, false)
+          .squeeze(-1)
+          .exp();
+  auto tempa = temp - temperature_base;
+  bounds_mask.set_((lnp < ln_pressure[0]) | (lnp > ln_pressure[-1]) |
+                   (tempa < temperature_anomaly[0]) |
+                   (tempa > temperature_anomaly[-1]));
+
+  auto total_q = total.unsqueeze(0);
+  auto absorption =
+      torch::zeros({wavenumber.numel(), ncol, nlyr}, conc.options());
+  if (ln_linear.defined()) {
+    auto linear = interpn({lnp, tempa}, {ln_pressure, temperature_anomaly},
+                          ln_linear, false)
+                      .exp()
+                      .view({ncol, nlyr, wavenumber.numel(), nlinear})
+                      .sum(-1)
+                      .permute({2, 0, 1});
+    absorption += linear * total_q;
+  }
+  if (ln_binary.defined()) {
+    auto binary = interpn({lnp, tempa}, {ln_pressure, temperature_anomaly},
+                          ln_binary, false)
+                      .exp()
+                      .view({ncol, nlyr, wavenumber.numel(), nbinary})
+                      .sum(-1)
+                      .permute({2, 0, 1});
+    absorption += binary * total_q.square();
+  }
+  if (!scattering.defined()) return absorption.unsqueeze(-1);
+
+  auto scattering_alpha =
+      scattering.to(conc.options()).view({-1, 1, 1}) * total_q;
+  auto extinction = absorption + scattering_alpha;
+  auto out =
+      torch::zeros({wavenumber.numel(), ncol, nlyr, 2 + scattering_moments()},
+                   conc.options());
+  out.select(-1, 0) = extinction;
+  out.select(-1, 1) = (scattering_alpha / extinction).clamp_max(1. - 1.e-12);
+  out.narrow(-1, 2, scattering_moments()) =
+      phase_moment.to(conc.options())
+          .unsqueeze(1)
+          .unsqueeze(1)
+          .expand({wavenumber.numel(), ncol, nlyr, scattering_moments()});
+  return out;
+}
+
+}  // namespace harp

--- a/src/opacity/respq_table.hpp
+++ b/src/opacity/respq_table.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <torch/nn/cloneable.h>
+#include <torch/nn/module.h>
+#include <torch/torch.h>
+
+#include "opacity_options.hpp"
+
+namespace harp {
+
+class RespqTableImpl : public torch::nn::Cloneable<RespqTableImpl> {
+ public:
+  torch::Tensor wavenumber, weights, wave_lower, wave_upper;
+  torch::Tensor ln_pressure, temperature_anomaly, ln_temperature_base;
+  torch::Tensor ln_linear, ln_binary, scattering, phase_moment;
+  torch::Tensor reference_mole_fraction, bounds_mask;
+  int nlinear = 0, nbinary = 0;
+
+  OpacityOptions options;
+
+  RespqTableImpl() : options(OpacityOptionsImpl::create()) {}
+  explicit RespqTableImpl(OpacityOptions const& options_);
+  void reset() override;
+  int scattering_moments() const;
+
+  torch::Tensor forward(torch::Tensor conc,
+                        std::map<std::string, torch::Tensor> const& kwargs);
+};
+TORCH_MODULE(RespqTable);
+
+}  // namespace harp

--- a/src/radiation/radiation_band.cpp
+++ b/src/radiation/radiation_band.cpp
@@ -14,6 +14,7 @@
 #include <harp/opacity/opacity_formatter.hpp>
 #include <harp/opacity/picaso_ck.hpp>
 #include <harp/opacity/rayleigh.hpp>
+#include <harp/opacity/respq_table.hpp>
 #include <harp/opacity/wavetemp.hpp>
 #include <harp/utils/layer2level.hpp>
 #include <harp/utils/parse_yaml_input.hpp>
@@ -43,6 +44,12 @@ torch::Tensor divide_where_positive(torch::Tensor numerator,
       torch::where(positive, denominator, torch::ones_like(denominator));
   return torch::where(positive, numerator / safe_denominator,
                       torch::zeros_like(numerator));
+}
+
+std::vector<double> to_vector(torch::Tensor const& tensor) {
+  auto data = tensor.to(torch::kCPU, torch::kFloat64).contiguous();
+  return std::vector<double>(data.data_ptr<double>(),
+                             data.data_ptr<double>() + data.numel());
 }
 
 }  // namespace
@@ -186,6 +193,7 @@ void RadiationBandImpl::reset() {
 
   // create opacities
   int nmax_prop = 1;
+  int nrespq = 0;
 
   for (auto const& [name, op] : options->opacities()) {
     if (op->type() == "jit") {
@@ -207,6 +215,13 @@ void RadiationBandImpl::reset() {
       auto a = PicasoCK(op);
       nmax_prop = std::max(nmax_prop, 1);
       opacities[name] = torch::nn::AnyModule(a);
+    } else if (op->type() == "respq-table") {
+      auto a = RespqTable(op);
+      nmax_prop = std::max(nmax_prop, a->scattering_moments() == 0
+                                          ? 1
+                                          : 2 + a->scattering_moments());
+      opacities[name] = torch::nn::AnyModule(a);
+      ++nrespq;
     } else if (op->type() == "wavetemp") {
       auto a = WaveTemp(op);
       nmax_prop = std::max(nmax_prop, 1);
@@ -227,6 +242,19 @@ void RadiationBandImpl::reset() {
       TORCH_CHECK(false, "Unknown opacity type: ", op->type());
     }
     register_module(name, opacities[name].ptr());
+  }
+  if (nrespq > 0) {
+    TORCH_CHECK(nrespq == 1 && opacities.size() == 1,
+                "A respq-table must be the band's only opacity source");
+    TORCH_CHECK(options->wavenumber().empty() && options->weight().empty(),
+                "A respq-table supplies the band quadrature");
+    auto const& table = opacities.begin()->second.get<RespqTableImpl>();
+    TORCH_CHECK(options->nwave() == table.wavenumber.numel(),
+                "band nwave must match the respq-table point count");
+    options->wavenumber(to_vector(table.wavenumber))
+        .weight(to_vector(table.weights))
+        .set_wave_lower(to_vector(table.wave_lower))
+        .set_wave_upper(to_vector(table.wave_upper));
   }
   if (options->solver_name() == "toon") nmax_prop = std::max(nmax_prop, 3);
 

--- a/src/radiation/radiation_band.hpp
+++ b/src/radiation/radiation_band.hpp
@@ -36,6 +36,7 @@ using OpacityDict = std::map<std::string, OpacityOptions>;
  * dumps
  *  - "multiband-ck": multi-band correlated-k opacity table
  *  - "picaso-ck": PICASO correlated-k NetCDF table
+ *  - "respq-table": ReSPQ quadrature and optical-property table
  *  - "wavetemp": opacity table defined on wavenumber and temperature grid (CIA)
  *  - "fourcolumn": Four-column opacity table (aerosol)
  *  - "rayleigh": gas Rayleigh scattering computed on the active spectral grid

--- a/tests/test_attenuator.cpp
+++ b/tests/test_attenuator.cpp
@@ -15,6 +15,9 @@
 #include <harp/opacity/molecule_cia.hpp>
 #include <harp/opacity/molecule_line.hpp>
 #include <harp/opacity/opacity_options.hpp>
+#include <harp/opacity/respq_table.hpp>
+#include <harp/radiation/radiation_band.hpp>
+#include <harp/rtsolver/toon_mckay89.hpp>
 
 // netcdf
 #ifdef NETCDFOUTPUT
@@ -113,6 +116,78 @@ fs::path write_test_dataset() {
   check_nc(nc_put_var_double(fileid, var_cia, sigma_cia.data()));
   check_nc(nc_close(fileid));
 
+  return path;
+}
+
+fs::path write_respq_dataset() {
+  auto path = fs::temp_directory_path() / "pyharp_test_respq.nc";
+  int fileid = -1;
+  check_nc(nc_create(path.c_str(), NC_CLOBBER, &fileid));
+
+  int point = -1, pressure = -1, offset = -1, species = -1;
+  int linear = -1, binary = -1, moment = -1;
+  check_nc(nc_def_dim(fileid, "point", 2, &point));
+  check_nc(nc_def_dim(fileid, "pressure", 2, &pressure));
+  check_nc(nc_def_dim(fileid, "temperature_offset", 2, &offset));
+  check_nc(nc_def_dim(fileid, "species", 2, &species));
+  check_nc(nc_def_dim(fileid, "linear_component", 1, &linear));
+  check_nc(nc_def_dim(fileid, "binary_component", 1, &binary));
+  check_nc(nc_def_dim(fileid, "moment", 2, &moment));
+
+  auto define_1d = [&](char const* name, int dim) {
+    int varid = -1;
+    check_nc(nc_def_var(fileid, name, NC_DOUBLE, 1, &dim, &varid));
+    return varid;
+  };
+  int wave = define_1d("wavenumber", point);
+  int lower = define_1d("wavenumber_lower", point);
+  int upper = define_1d("wavenumber_upper", point);
+  int weight = define_1d("quadrature_weight", point);
+  int pres = define_1d("pressure", pressure);
+  int temp_offset = define_1d("temperature_offset", offset);
+  int temp_base = define_1d("nominal_temperature", pressure);
+  int fraction = define_1d("reference_mole_fraction", species);
+  int scatter = define_1d("scattering_coefficient", point);
+  int linear_dims[4] = {linear, point, pressure, offset};
+  int binary_dims[4] = {binary, point, pressure, offset};
+  int moment_dims[2] = {point, moment};
+  int klinear = -1, kbinary = -1, pmom = -1;
+  check_nc(
+      nc_def_var(fileid, "kappa_linear", NC_DOUBLE, 4, linear_dims, &klinear));
+  check_nc(
+      nc_def_var(fileid, "kappa_binary", NC_DOUBLE, 4, binary_dims, &kbinary));
+  check_nc(
+      nc_def_var(fileid, "phase_moment", NC_DOUBLE, 2, moment_dims, &pmom));
+  put_text_attr(fileid, klinear, "units", "m2 mol-1");
+  put_text_attr(fileid, kbinary, "units", "m5 mol-2");
+  put_text_attr(fileid, scatter, "units", "m2 mol-1");
+  check_nc(nc_enddef(fileid));
+
+  double const wave_data[] = {100., 200.};
+  double const lower_data[] = {99.5, 199.5};
+  double const upper_data[] = {100.5, 200.5};
+  double const weight_data[] = {1., 2.};
+  double const pressure_data[] = {1.e5, 1.e6};
+  double const offset_data[] = {-10., 10.};
+  double const base_data[] = {300., 500.};
+  double const fraction_data[] = {.75, .25};
+  double const scattering_data[] = {1., 2.};
+  double const linear_data[] = {2., 2., 2., 2., 3., 3., 3., 3.};
+  double const binary_data[] = {.5, .5, .5, .5, .25, .25, .25, .25};
+  double const moment_data[] = {1., .1, 1., .2};
+  check_nc(nc_put_var_double(fileid, wave, wave_data));
+  check_nc(nc_put_var_double(fileid, lower, lower_data));
+  check_nc(nc_put_var_double(fileid, upper, upper_data));
+  check_nc(nc_put_var_double(fileid, weight, weight_data));
+  check_nc(nc_put_var_double(fileid, pres, pressure_data));
+  check_nc(nc_put_var_double(fileid, temp_offset, offset_data));
+  check_nc(nc_put_var_double(fileid, temp_base, base_data));
+  check_nc(nc_put_var_double(fileid, fraction, fraction_data));
+  check_nc(nc_put_var_double(fileid, scatter, scattering_data));
+  check_nc(nc_put_var_double(fileid, klinear, linear_data));
+  check_nc(nc_put_var_double(fileid, kbinary, binary_data));
+  check_nc(nc_put_var_double(fileid, pmom, moment_data));
+  check_nc(nc_close(fileid));
   return path;
 }
 #endif
@@ -221,6 +296,52 @@ TEST(TestOpacity, MoleculeOpacitiesClampTemperatureAnomalyToTableBounds) {
   auto cia_above_bound = evaluate(cia, 330.0);
   EXPECT_TRUE(torch::allclose(cia_below_bound, cia_lower_bound));
   EXPECT_TRUE(torch::allclose(cia_above_bound, cia_upper_bound));
+#endif
+}
+
+TEST(TestOpacity, RespqTableCombinesComponentsAndClampsBounds) {
+#ifndef NETCDFOUTPUT
+  GTEST_SKIP() << "NetCDF support is disabled";
+#else
+  auto dataset = write_respq_dataset();
+  auto options = harp::OpacityOptionsImpl::create();
+  options->type("respq-table")
+      .species_ids({0, 1})
+      .opacity_files({dataset.string()});
+  harp::RespqTable table(options);
+
+  auto conc = torch::tensor({{{3., 1.}}}, torch::kFloat64);
+  std::map<std::string, torch::Tensor> atm;
+  atm["pres"] = torch::tensor({{1.e5}}, torch::kFloat64);
+  atm["temp"] = torch::tensor({{300.}}, torch::kFloat64);
+  atm["wavenumber"] = torch::tensor({100., 200.}, torch::kFloat64);
+  auto result = table->forward(conc, atm);
+  EXPECT_TRUE(torch::allclose(result.select(-1, 0).flatten(),
+                              torch::tensor({20., 24.}, torch::kFloat64)));
+  EXPECT_TRUE(torch::allclose(result.select(-1, 1).flatten(),
+                              torch::tensor({.2, 1. / 3.}, torch::kFloat64)));
+  EXPECT_FALSE(torch::any(table->bounds_mask).item<bool>());
+
+  atm["pres"] = torch::tensor({{1.e4}}, torch::kFloat64);
+  atm["temp"] = torch::tensor({{1000.}}, torch::kFloat64);
+  EXPECT_TRUE(torch::allclose(table->forward(conc, atm), result));
+  EXPECT_TRUE(torch::all(table->bounds_mask).item<bool>());
+
+  auto wrong = torch::tensor({{{2., 2.}}}, torch::kFloat64);
+  EXPECT_THROW(table->forward(wrong, atm), c10::Error);
+
+  auto band_options = harp::RadiationBandOptionsImpl::create();
+  band_options->name("stellar")
+      .solver_name("toon")
+      .toon(harp::ToonMcKay89OptionsImpl::create())
+      .nwave(2)
+      .ncol(1)
+      .nlyr(1);
+  band_options->opacities()["respq"] = options;
+  harp::RadiationBand band(band_options);
+  EXPECT_EQ(band_options->weight(), (std::vector<double>{1., 2.}));
+  EXPECT_EQ(band_options->toon()->wave_lower(),
+            (std::vector<double>{99.5, 199.5}));
 #endif
 }
 


### PR DESCRIPTION
## Summary

- add a NetCDF-backed `respq-table` opacity source
- load frozen quadrature points, bounds, weights, and fixed-composition optical properties
- support absorption-only longwave tables and shortwave tables with scattering and phase moments
- use the existing RadiationBand solver path for DISORT and Toon
- clamp pressure and temperature lookup to table bounds and expose `bounds_mask`

## Validation

- repository pre-commit hooks pass
- clean NetCDF-enabled C++ build passes
- applicable CPU tests pass, including the new table integration test
- real 1408-point LW and SW tables reproduce the reference fluxes to about 3e-6 W m-2 RMSE