### PR TITLE
Split H2O continuum into self and foreign components

### DIFF
--- a/docs/source/dump_cli.rst
+++ b/docs/source/dump_cli.rst
@@ -214,9 +214,15 @@ Single-species xsection dumps use names such as:
 
 * ``sigma_line_h2o``
 * ``sigma_continuum_h2o_mt_ckd``
+* ``sigma_continuum_h2o_self_mt_ckd``
+* ``sigma_continuum_h2o_foreign_mt_ckd``
 * ``sigma_cia_h2o_h2o``
 * ``binary_absorption_coefficient_h2o_h2o``
 * ``sigma_total``
+
+The two split MT_CKD fields contain unit-VMR self and foreign components.
+``MoleculeLine`` weights them at runtime by ``xH2O`` and ``1 - xH2O``.  The
+combined ``sigma_continuum_h2o_mt_ckd`` field remains for older readers.
 
 Pair xsection dumps use:
 

--- a/docs/source/dump_cli.rst
+++ b/docs/source/dump_cli.rst
@@ -213,7 +213,6 @@ Xsection outputs
 Single-species xsection dumps use names such as:
 
 * ``sigma_line_h2o``
-* ``sigma_continuum_h2o_mt_ckd``
 * ``sigma_continuum_h2o_self_mt_ckd``
 * ``sigma_continuum_h2o_foreign_mt_ckd``
 * ``sigma_cia_h2o_h2o``
@@ -222,7 +221,8 @@ Single-species xsection dumps use names such as:
 
 The two split MT_CKD fields contain unit-VMR self and foreign components.
 ``MoleculeLine`` weights them at runtime by ``xH2O`` and ``1 - xH2O``.  The
-combined ``sigma_continuum_h2o_mt_ckd`` field remains for older readers.
+new reader also falls back to the combined ``sigma_continuum_h2o_mt_ckd``
+field found in older tables; old readers cannot consume the new split format.
 
 Pair xsection dumps use:
 

--- a/docs/source/opacity.rst
+++ b/docs/source/opacity.rst
@@ -64,6 +64,11 @@ Line opacity variables follow the naming convention ``sigma_line_<species>``.
 Optional same-species continuum terms use ``sigma_continuum_<species>_*`` and
 are summed into the line attenuation automatically. CIA variables use
 ``binary_absorption_coefficient_<species_a>_<species_b>``.
+For H2O, paired ``sigma_continuum_h2o_self_mt_ckd`` and
+``sigma_continuum_h2o_foreign_mt_ckd`` fields are unit-VMR components;
+``MoleculeLine`` applies the runtime water and non-water mole fractions before
+multiplying by the H2O molar concentration. A legacy combined MT_CKD field is
+used only when the split pair is absent.
 
 Rayleigh scattering is configured as a separate opacity source on the same
 line-by-line grid. It does not need to be stored in the absorption NetCDF file:

--- a/python/spectra/dump_cli.py
+++ b/python/spectra/dump_cli.py
@@ -313,6 +313,8 @@ def _xsection_dataset(
                     "composition_weight": "runtime",
                 },
             )
+        if secondary_component.get("continuum_components"):
+            dataset = dataset.drop_vars(cia_name)
     else:
         dataset[cia_name].attrs = {"long_name": f"{secondary_component['label']} CIA absorption cross section", "units": "cm^2 molecule^-1"}
         binary = np.asarray(secondary_component["binary_absorption_coefficient"], dtype=np.float64)

--- a/python/spectra/dump_cli.py
+++ b/python/spectra/dump_cli.py
@@ -27,6 +27,7 @@ from .dataset_io import (
 )
 from .hitran_cia_utils import load_cia_dataset
 from .hitran_molecule_utils import build_line_provider, download_hitran_lines
+from .mt_ckd_h2o import compute_mt_ckd_h2o_continuum_components
 from .orton_xiz_cia import load_orton_xiz_cia_dataset, resolve_orton_xiz_cia_filename
 from .utils import (
     HelpFormatter,
@@ -301,6 +302,17 @@ def _xsection_dataset(
         dataset["sigma_cia"].attrs = {"long_name": "CIA or continuum absorption cross section", "units": "cm^2 molecule^-1"}
     elif cia_name.startswith("sigma_continuum_"):
         dataset[cia_name].attrs = {"long_name": f"{secondary_component['label']} absorption cross section", "units": "cm^2 molecule^-1"}
+        for component, values in secondary_component.get("continuum_components", {}).items():
+            name = f"sigma_continuum_h2o_{component}_mt_ckd"
+            dataset[name] = (
+                "wavenumber",
+                np.asarray(values, dtype=np.float64),
+                {
+                    "long_name": f"MT_CKD H2O {component} continuum unit-VMR cross section",
+                    "units": "cm^2 molecule^-1",
+                    "composition_weight": "runtime",
+                },
+            )
     else:
         dataset[cia_name].attrs = {"long_name": f"{secondary_component['label']} CIA absorption cross section", "units": "cm^2 molecule^-1"}
         binary = np.asarray(secondary_component["binary_absorption_coefficient"], dtype=np.float64)
@@ -669,7 +681,16 @@ def _compute_species_xsection(args: argparse.Namespace):
             pressure_pa=pressure_pa,
         )
         if cia_cross_section_cm2_molecule is not None:
-            secondary_component = {"kind": "continuum", "label": "H2O continuum (MT_CKD)"}
+            sigma_self, sigma_foreign = compute_mt_ckd_h2o_continuum_components(
+                wavenumber_grid_cm1=grid,
+                temperature_k=temperature_k,
+                pressure_pa=pressure_pa,
+            )
+            secondary_component = {
+                "kind": "continuum",
+                "label": "H2O continuum (MT_CKD)",
+                "continuum_components": {"self": sigma_self, "foreign": sigma_foreign},
+            }
     elif cia_selection is not None:
         pair, _ = cia_selection
         secondary_component = {

--- a/python/spectra/mt_ckd_h2o.py
+++ b/python/spectra/mt_ckd_h2o.py
@@ -61,6 +61,23 @@ def compute_mt_ckd_h2o_continuum_cross_section(
     if not (0.0 <= foreign_vmr <= 1.0):
         raise ValueError("foreign_vmr must be between 0 and 1.")
 
+    sigma_self, sigma_foreign = compute_mt_ckd_h2o_continuum_components(
+        wavenumber_grid_cm1=wavenumber_grid_cm1,
+        temperature_k=temperature_k,
+        pressure_pa=pressure_pa,
+        data_path=data_path,
+    )
+    return float(h2o_vmr) * sigma_self + float(foreign_vmr) * sigma_foreign
+
+
+def compute_mt_ckd_h2o_continuum_components(
+    *,
+    wavenumber_grid_cm1: np.ndarray,
+    temperature_k: float,
+    pressure_pa: float,
+    data_path: Path | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return unit-VMR MT_CKD self and foreign cross sections in cm^2/molecule."""
     resolved_path = default_mt_ckd_h2o_data_path() if data_path is None else Path(data_path)
     if not resolved_path.exists():
         raise FileNotFoundError(
@@ -80,19 +97,21 @@ def compute_mt_ckd_h2o_continuum_cross_section(
         ref_temp_k = float(dataset["ref_temp"].values)
 
     rho_ratio = (pressure_mbar / ref_press_mbar) * (ref_temp_k / float(temperature_k))
-    sigma_self = self_absco_ref * (ref_temp_k / float(temperature_k)) ** self_texp
-    sigma_self = sigma_self * float(h2o_vmr) * rho_ratio
-    sigma_foreign = foreign_absco_ref * float(foreign_vmr) * rho_ratio
-    continuum_ref = (sigma_self + sigma_foreign) * _radiation_term(reference_grid, float(temperature_k))
+    radiation = _radiation_term(reference_grid, float(temperature_k))
+    self_ref = self_absco_ref * (ref_temp_k / float(temperature_k)) ** self_texp * rho_ratio * radiation
+    foreign_ref = foreign_absco_ref * rho_ratio * radiation
 
-    interpolator = interp1d(
-        reference_grid,
-        continuum_ref,
-        kind="cubic",
-        bounds_error=False,
-        fill_value=0.0,
-        assume_sorted=True,
-    )
-    continuum = np.asarray(interpolator(target_grid), dtype=np.float64)
-    continuum[continuum < 0.0] = 0.0
-    return continuum
+    def interpolate(values: np.ndarray) -> np.ndarray:
+        interpolator = interp1d(
+            reference_grid,
+            values,
+            kind="cubic",
+            bounds_error=False,
+            fill_value=0.0,
+            assume_sorted=True,
+        )
+        result = np.asarray(interpolator(target_grid), dtype=np.float64)
+        result[result < 0.0] = 0.0
+        return result
+
+    return interpolate(self_ref), interpolate(foreign_ref)

--- a/src/opacity/molecule_line.cpp
+++ b/src/opacity/molecule_line.cpp
@@ -80,18 +80,48 @@ void MoleculeLineImpl::reset() {
   int nvars = 0;
   check_nc(nc_inq_nvars(fileid, &nvars), "Failed to query variable count");
   auto const continuum_prefix = "sigma_continuum_" + species_token + "_";
+  auto const self_continuum_name = continuum_prefix + "self_mt_ckd";
+  auto const foreign_continuum_name = continuum_prefix + "foreign_mt_ckd";
+  auto const legacy_continuum_name = continuum_prefix + "mt_ckd";
+  torch::Tensor sigma_continuum_self;
+  torch::Tensor sigma_continuum_foreign;
+  torch::Tensor sigma_continuum_legacy;
   for (int i = 0; i < nvars; ++i) {
     char name[NC_MAX_NAME + 1] = {};
     check_nc(nc_inq_varname(fileid, i, name), "Failed to query variable name");
     std::string varname(name);
     if (varname.rfind(continuum_prefix, 0) != 0) continue;
 
-    sigma_cross +=
+    auto continuum =
         convert_line_cross_section_to_m2_per_mol(
             read_tensor_permuted(fileid, varname,
                                  {"wavenumber", "pressure", "del_temperature"}),
             read_var_units(fileid, i), varname)
             .unsqueeze(-1);
+    if (varname == self_continuum_name) {
+      sigma_continuum_self = continuum;
+    } else if (varname == foreign_continuum_name) {
+      sigma_continuum_foreign = continuum;
+    } else if (varname == legacy_continuum_name) {
+      sigma_continuum_legacy = continuum;
+    } else {
+      sigma_cross += continuum;
+    }
+  }
+
+  auto const has_self = sigma_continuum_self.defined();
+  auto const has_foreign = sigma_continuum_foreign.defined();
+  TORCH_CHECK(has_self == has_foreign, "Split H2O continuum requires both ",
+              self_continuum_name, " and ", foreign_continuum_name);
+  has_split_h2o_continuum = has_self && has_foreign;
+  if (has_split_h2o_continuum) {
+    ln_sigma_continuum_self =
+        apply_positive_fill(sigma_continuum_self, self_continuum_name).log();
+    ln_sigma_continuum_foreign =
+        apply_positive_fill(sigma_continuum_foreign, foreign_continuum_name)
+            .log();
+  } else if (sigma_continuum_legacy.defined()) {
+    sigma_cross += sigma_continuum_legacy;
   }
 
   sigma_cross = apply_positive_fill(sigma_cross, line_name);
@@ -108,6 +138,10 @@ void MoleculeLineImpl::reset() {
   register_buffer("temperature_anomaly", temperature_anomaly);
   register_buffer("ln_sigma_cross", ln_sigma_cross);
   register_buffer("ln_temperature_base", ln_temperature_base);
+  if (has_split_h2o_continuum) {
+    register_buffer("ln_sigma_continuum_self", ln_sigma_continuum_self);
+    register_buffer("ln_sigma_continuum_foreign", ln_sigma_continuum_foreign);
+  }
 }
 
 torch::Tensor MoleculeLineImpl::forward(
@@ -152,18 +186,33 @@ torch::Tensor MoleculeLineImpl::forward(
 
   // Clamp queries to the tabulated bounds. Extrapolating logarithmic line
   // cross sections can produce nonphysical opacity outside the table coverage.
-  auto out = interpn({wave, lnp, tempa},
-                     {wavenumber, ln_pressure, temperature_anomaly},
-                     ln_sigma_cross, false)
-                 .exp();
+  auto query = std::vector<torch::Tensor>{wave, lnp, tempa};
+  auto coordinates =
+      std::vector<torch::Tensor>{wavenumber, ln_pressure, temperature_anomaly};
+  auto out = interpn(query, coordinates, ln_sigma_cross, false).exp();
 
   // Check species id in range
   TORCH_CHECK(options->species_ids()[0] >= 0 &&
                   options->species_ids()[0] < conc.size(2),
               "Invalid species_id: ", options->species_ids()[0]);
 
-  return out *
-         conc.select(-1, options->species_ids()[0]).unsqueeze(0).unsqueeze(-1);
+  auto water_conc = conc.select(-1, options->species_ids()[0]);
+  if (has_split_h2o_continuum) {
+    auto total_conc = conc.sum(-1);
+    TORCH_CHECK(torch::all(total_conc > 0.0).item<bool>(),
+                "Total gas concentration must be positive");
+    TORCH_CHECK(torch::all(water_conc >= 0.0).item<bool>(),
+                "H2O concentration must be non-negative");
+    auto h2o_vmr = water_conc / total_conc;
+    auto sigma_self =
+        interpn(query, coordinates, ln_sigma_continuum_self, false).exp();
+    auto sigma_foreign =
+        interpn(query, coordinates, ln_sigma_continuum_foreign, false).exp();
+    out += h2o_vmr.unsqueeze(0).unsqueeze(-1) * sigma_self;
+    out += (1.0 - h2o_vmr).unsqueeze(0).unsqueeze(-1) * sigma_foreign;
+  }
+
+  return out * water_conc.unsqueeze(0).unsqueeze(-1);
 }
 
 }  // namespace harp

--- a/src/opacity/molecule_line.hpp
+++ b/src/opacity/molecule_line.hpp
@@ -18,9 +18,14 @@ class MoleculeLineImpl : public torch::nn::Cloneable<MoleculeLineImpl> {
   //! (nwave,) (npres,) (ndeltemp,)
   torch::Tensor wavenumber, ln_pressure, temperature_anomaly;
 
-  //! tabulated ln(line + same-species continuum cross section) [ln(m^2/mol)]
+  //! tabulated ln(line + legacy composition-weighted continuum) [ln(m^2/mol)]
   //! (nwave, npres, ndeltemp, 1)
   torch::Tensor ln_sigma_cross;
+
+  //! tabulated unit-VMR H2O continuum components [ln(m^2/mol)]
+  //! (nwave, npres, ndeltemp, 1)
+  torch::Tensor ln_sigma_continuum_self, ln_sigma_continuum_foreign;
+  bool has_split_h2o_continuum = false;
 
   //! ln(base temperature profile) [ln(K)]
   //! (npres, 1)

--- a/tests/spectra/test_cli.py
+++ b/tests/spectra/test_cli.py
@@ -864,15 +864,25 @@ def test_xsection_dataset_keeps_only_sigma_fields() -> None:
     dataset = _xsection_dataset(
         spectrum,
         species_name="H2O",
-        secondary_component={"kind": "continuum", "label": "H2O continuum (MT_CKD)"},
+        secondary_component={
+            "kind": "continuum",
+            "label": "H2O continuum (MT_CKD)",
+            "continuum_components": {
+                "self": np.array([0.3, 0.4]),
+                "foreign": np.array([0.5, 0.6]),
+            },
+        },
         wn_range=(20.0, 22.0),
     )
     try:
         assert set(dataset.data_vars) == {
             "sigma_line_h2o",
             "sigma_continuum_h2o_mt_ckd",
+            "sigma_continuum_h2o_self_mt_ckd",
+            "sigma_continuum_h2o_foreign_mt_ckd",
             "sigma_total",
         }
+        assert dataset["sigma_continuum_h2o_self_mt_ckd"].attrs["composition_weight"] == "runtime"
         assert dataset.attrs["band_wavenumber_min_cm1"] == 20.0
         assert dataset.attrs["band_wavenumber_max_cm1"] == 22.0
     finally:
@@ -1316,14 +1326,21 @@ def test_cli_xsection_reuses_built_provider_for_species_spectrum(monkeypatch, tm
     monkeypatch.setattr("pyharp.spectra.dump_cli.download_hitran_lines", lambda config, band: object())
     monkeypatch.setattr("pyharp.spectra.dump_cli.build_line_provider", lambda config, line_db: fake_provider)
     monkeypatch.setattr("pyharp.spectra.dump_cli._resolve_species_cia", lambda args, config: None)
+    monkeypatch.setattr(
+        "pyharp.spectra.dump_cli.compute_mt_ckd_h2o_continuum_components",
+        lambda **kwargs: (
+            np.array([3.0e-24, 4.0e-24, 5.0e-24]),
+            np.array([6.0e-24, 7.0e-24, 8.0e-24]),
+        ),
+    )
 
     def fake_resolve_continuum_sources(*, config, wavenumber_grid_cm1, temperature_k, pressure_pa):
         calls["resolve"] += 1
         assert config.hitran_species.name == "H2O"
-        assert np.allclose(wavenumber_grid_cm1, np.array([20.0, 21.0]))
+        assert np.allclose(wavenumber_grid_cm1, np.array([20.0, 21.0, 22.0]))
         assert temperature_k == 300.0
         assert pressure_pa == 1.0e5
-        return None, np.array([1.0e-24, 2.0e-24])
+        return None, np.array([1.0e-24, 2.0e-24, 3.0e-24])
 
     def fake_compute_from_sources(
         *,
@@ -1337,12 +1354,12 @@ def test_cli_xsection_reuses_built_provider_for_species_spectrum(monkeypatch, tm
     ):
         calls["compute"] += 1
         assert species_name == "H2O"
-        assert np.allclose(wavenumber_grid_cm1, np.array([20.0, 21.0]))
+        assert np.allclose(wavenumber_grid_cm1, np.array([20.0, 21.0, 22.0]))
         assert temperature_k == 300.0
         assert pressure_pa == 1.0e5
         assert line_provider is fake_provider
         assert cia_dataset is None
-        assert np.allclose(cia_cross_section_cm2_molecule, np.array([1.0e-24, 2.0e-24]))
+        assert np.allclose(cia_cross_section_cm2_molecule, np.array([1.0e-24, 2.0e-24, 3.0e-24]))
         return type("Spectrum", (), {})()
 
     monkeypatch.setattr("pyharp.spectra.dump_cli._resolve_continuum_sources", fake_resolve_continuum_sources)

--- a/tests/spectra/test_cli.py
+++ b/tests/spectra/test_cli.py
@@ -877,7 +877,6 @@ def test_xsection_dataset_keeps_only_sigma_fields() -> None:
     try:
         assert set(dataset.data_vars) == {
             "sigma_line_h2o",
-            "sigma_continuum_h2o_mt_ckd",
             "sigma_continuum_h2o_self_mt_ckd",
             "sigma_continuum_h2o_foreign_mt_ckd",
             "sigma_total",

--- a/tests/spectra/test_mt_ckd_h2o.py
+++ b/tests/spectra/test_mt_ckd_h2o.py
@@ -4,7 +4,11 @@ import numpy as np
 import xarray as xr
 
 from pyharp.spectra.mt_ckd_h2o import default_mt_ckd_h2o_data_path
-from pyharp.spectra.mt_ckd_h2o import _radiation_term, compute_mt_ckd_h2o_continuum_cross_section
+from pyharp.spectra.mt_ckd_h2o import (
+    _radiation_term,
+    compute_mt_ckd_h2o_continuum_components,
+    compute_mt_ckd_h2o_continuum_cross_section,
+)
 
 
 def test_default_mt_ckd_h2o_data_path_uses_local_external_directory(monkeypatch) -> None:
@@ -50,6 +54,12 @@ def test_compute_mt_ckd_h2o_continuum_includes_self_and_foreign_terms(tmp_path) 
         foreign_vmr=0.75,
         data_path=data_path,
     )
+    sigma_self, sigma_foreign = compute_mt_ckd_h2o_continuum_components(
+        wavenumber_grid_cm1=reference_grid,
+        temperature_k=200.0,
+        pressure_pa=1.2e5,
+        data_path=data_path,
+    )
 
     rho_ratio = (1200.0 / 1000.0) * (250.0 / 200.0)
     expected = (
@@ -57,6 +67,7 @@ def test_compute_mt_ckd_h2o_continuum_includes_self_and_foreign_terms(tmp_path) 
         + foreign_absco_ref * 0.75
     ) * rho_ratio * _radiation_term(reference_grid, 200.0)
     assert np.allclose(result, expected)
+    assert np.allclose(result, 0.25 * sigma_self + 0.75 * sigma_foreign)
 
 
 def test_compute_mt_ckd_h2o_continuum_defaults_foreign_to_remaining_fraction(tmp_path) -> None:

--- a/tests/test_attenuator.cpp
+++ b/tests/test_attenuator.cpp
@@ -44,8 +44,10 @@ void put_text_attr(int fileid, int varid, char const* name, char const* value) {
   check_nc(nc_put_att_text(fileid, varid, name, std::strlen(value), value));
 }
 
-fs::path write_test_dataset() {
-  auto path = fs::temp_directory_path() / "pyharp_test_molecule_line.nc";
+fs::path write_test_dataset(bool split_continuum = false) {
+  auto path = fs::temp_directory_path() /
+              (split_continuum ? "pyharp_test_molecule_line_split.nc"
+                               : "pyharp_test_molecule_line.nc");
   int fileid = -1;
   check_nc(nc_create(path.c_str(), NC_CLOBBER, &fileid));
 
@@ -56,6 +58,7 @@ fs::path write_test_dataset() {
 
   int var_wavenumber = -1, var_pressure = -1, var_del_temp = -1;
   int var_temperature = -1, var_line = -1, var_cont = -1, var_cia = -1;
+  int var_cont_self = -1, var_cont_foreign = -1;
   check_nc(nc_def_var(fileid, "wavenumber", NC_DOUBLE, 1, &dim_wavenumber,
                       &var_wavenumber));
   check_nc(nc_def_var(fileid, "pressure", NC_DOUBLE, 1, &dim_pressure,
@@ -70,6 +73,12 @@ fs::path write_test_dataset() {
       nc_def_var(fileid, "sigma_line_h2o", NC_DOUBLE, 3, dims3, &var_line));
   check_nc(nc_def_var(fileid, "sigma_continuum_h2o_mt_ckd", NC_DOUBLE, 3, dims3,
                       &var_cont));
+  if (split_continuum) {
+    check_nc(nc_def_var(fileid, "sigma_continuum_h2o_self_mt_ckd", NC_DOUBLE, 3,
+                        dims3, &var_cont_self));
+    check_nc(nc_def_var(fileid, "sigma_continuum_h2o_foreign_mt_ckd", NC_DOUBLE,
+                        3, dims3, &var_cont_foreign));
+  }
   check_nc(nc_def_var(fileid, "binary_absorption_coefficient_h2_he", NC_DOUBLE,
                       3, dims3, &var_cia));
 
@@ -79,6 +88,10 @@ fs::path write_test_dataset() {
   put_text_attr(fileid, var_temperature, "units", "K");
   put_text_attr(fileid, var_line, "units", "cm^2 molecule^-1");
   put_text_attr(fileid, var_cont, "units", "cm^2 molecule^-1");
+  if (split_continuum) {
+    put_text_attr(fileid, var_cont_self, "units", "cm^2 molecule^-1");
+    put_text_attr(fileid, var_cont_foreign, "units", "cm^2 molecule^-1");
+  }
   put_text_attr(fileid, var_cia, "units", "cm^5 molecule^-2");
 
   check_nc(nc_enddef(fileid));
@@ -90,6 +103,8 @@ fs::path write_test_dataset() {
 
   std::vector<double> sigma_line(2 * 2 * 3);
   std::vector<double> sigma_cont(2 * 2 * 3);
+  std::vector<double> sigma_cont_self(2 * 2 * 3, 2.0e-24);
+  std::vector<double> sigma_cont_foreign(2 * 2 * 3, 6.0e-24);
   std::vector<double> sigma_cia(2 * 2 * 3);
 
   for (int idt = 0; idt < 2; ++idt) {
@@ -113,6 +128,11 @@ fs::path write_test_dataset() {
   check_nc(nc_put_var_double(fileid, var_temperature, temperature));
   check_nc(nc_put_var_double(fileid, var_line, sigma_line.data()));
   check_nc(nc_put_var_double(fileid, var_cont, sigma_cont.data()));
+  if (split_continuum) {
+    check_nc(nc_put_var_double(fileid, var_cont_self, sigma_cont_self.data()));
+    check_nc(
+        nc_put_var_double(fileid, var_cont_foreign, sigma_cont_foreign.data()));
+  }
   check_nc(nc_put_var_double(fileid, var_cia, sigma_cia.data()));
   check_nc(nc_close(fileid));
 
@@ -218,6 +238,37 @@ TEST(TestOpacity, MoleculeLineAddsContinuumAndHandlesDimensionOrder) {
   auto expected = expected_sigma * 2.0;
   EXPECT_TRUE(torch::allclose(result, expected, 1.0e-12, 1.0e-12));
   EXPECT_LT(result[0].item<double>(), 1.0e-250);
+#endif
+}
+
+TEST(TestOpacity, MoleculeLineWeightsSplitWaterContinuumAtRuntime) {
+#ifndef NETCDFOUTPUT
+  GTEST_SKIP() << "NetCDF support is disabled";
+#else
+  auto dataset = write_test_dataset(true);
+  harp::species_names = {"H2O", "H2", "He"};
+  harp::species_weights = {18.0e-3, 2.0e-3, 4.0e-3};
+
+  auto op = harp::OpacityOptionsImpl::create();
+  op->type("molecule-line").species_ids({0}).opacity_files({dataset.string()});
+  harp::MoleculeLine line(op);
+
+  auto conc = torch::zeros({1, 1, 3}, torch::kFloat64);
+  conc[0][0][0] = 1.0;
+  conc[0][0][1] = 3.0;
+  std::map<std::string, torch::Tensor> atm;
+  atm["pres"] = torch::tensor({{1.0e5}}, torch::kFloat64);
+  atm["temp"] = torch::tensor({{290.0}}, torch::kFloat64);
+  atm["wavenumber"] = torch::tensor({20.0, 21.0, 22.0}, torch::kFloat64);
+
+  auto result = line->forward(conc, atm).squeeze();
+  // xH2O=0.25: continuum = 0.25*2e-24 + 0.75*6e-24 = 5e-24.
+  // The legacy combined field is present but must be ignored when both split
+  // fields exist.
+  auto expected_sigma =
+      torch::tensor({5.0e-24, 7.0e-24, 8.0e-24}, torch::kFloat64) *
+      (1.0e-4 * harp::constants::Avogadro);
+  EXPECT_TRUE(torch::allclose(result, expected_sigma, 1.0e-12, 1.0e-12));
 #endif
 }
 


### PR DESCRIPTION
This PR separates the MT_CKD H2O continuum into self and foreign components, allowing their contributions to be scaled at runtime according to the actual H2O mixing ratio. 

The exported opacity tables now contain separate self and foreign continuum cross sections. MoleculeLine combines them at runtime using the local H2O and foreign-gas fractions. 

The updated reader remains compatible with legacy tables containing the combined H2O continuum field.